### PR TITLE
Use qemu image for multi-arch builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,15 +25,16 @@ before_install:
     echo "${DOCKERHUB_PULL_PASSWORD}" | docker login --username "${DOCKERHUB_PULL_USERNAME}" --password-stdin
   fi
 - docker --version
+- docker run --rm --privileged linuxkit/binfmt:v0.8
 - docker buildx create --use
 
 script:
-- docker ps
+- docker ps; docker buildx ls
 
 deploy:
   - provider: script
     edge: true
-    script: docker buildx build --platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x -t appwrite/test:2.0 ./ --push
+    script: docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x -t appwrite/test:2.0 ./ --push
     on:
       repo: appwrite/sdk-for-cli
       branch: master


### PR DESCRIPTION
The build was failing because `buildx` was activated, but qemu was missing. Because of this, the Travis container could only understand how to build x86 and x86_64. This PR adds `linuxkit/binfmt` as the qemu image, and now builds for all desired architectures.

Proof:
- https://travis-ci.com/github/kodumbeats/sdk-for-cli/builds/218992088
- https://hub.docker.com/layers/kodumbeats/appwriteclitest/0.3/images/sha256-93be81552c5f720da8b08b0cba87ef4707e6c50ec2091eec3bc29d88882abd93?context=explore
