### PR TITLE
Added a deploy option to preserve attribs order

### DIFF
--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -490,7 +490,7 @@ const createAttribute = async (databaseId, collectionId, attribute) => {
     }
 }
 
-const deployCollection = async ({ all, yes } = {}) => {
+const deployCollection = async ({ all, yes, preserve } = {}) => {
     let response = {};
 
     const collections = [];
@@ -636,9 +636,15 @@ const deployCollection = async ({ all, yes } = {}) => {
         // Create all non-relationship attributes first
         const attributes = collection.attributes.filter(attribute => attribute.type !== 'relationship');
 
-        await Promise.all(attributes.map(attribute => {
-            return createAttribute(databaseId, collection['$id'], attribute);
-        }));
+        if (preserve) {
+            for (const attribute of attributes) {
+                await createAttribute(databaseId, collection['$id'], attribute);
+            }
+        } else {
+            await Promise.all(attributes.map(attribute => {
+                return createAttribute(databaseId, collection['$id'], attribute);
+            }));
+        }
 
         let result = await awaitPools.expectAttributes(
             databaseId,
@@ -650,7 +656,7 @@ const deployCollection = async ({ all, yes } = {}) => {
             throw new Error("Attribute creation timed out.");
         }
 
-        success(`Created ${attributes.length} non-relationship attributes`);
+        success(`Created ${attributes.length} non-relationship attributes${preserve ? ', preserving order' : ''}`);
 
         log(`Creating indexes ...`)
 
@@ -881,6 +887,7 @@ deploy
     .description("Deploy collections in the current project.")
     .option(`--all`, `Flag to deploy all collections`)
     .option(`--yes`, `Flag to confirm all warnings`)
+    .option(`--preserve`, `Preserve attributes order`)
     .action(actionRunner(deployCollection));
 
 deploy


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

I added a `deploy collection` option for keeping the attributes ordered as they appear in the `appwrite.json` file.

## Test Plan

Install modules :
```
npm install
```

Test the help :
```
node ./index.js deploy collection --help
```

Prepare an `appwrite.json` file :
```
node ./index.js login
node ./index.js init project
node ./index.js init collection
```

[OPTIONAL] Test the randomness of the current attributes creation (pick a collection in the list and check the attributes order):
```
node ./index.js deploy collection
```

Test the new attributes creation (pick a collection in the list and check that the attributes order is kept as original one):
```
node ./index.js deploy collection --preserve
```

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

YES