### PR TITLE
fix: Update accountCreateEmailSession to accountCreateEmailPasswordSession

### DIFF
--- a/lib/commands/generic.js
+++ b/lib/commands/generic.js
@@ -5,7 +5,7 @@ const { sdkForConsole } = require("../sdks");
 const { globalConfig, localConfig } = require("../config");
 const { actionRunner, success, parseBool, commandDescriptions, log, parse } = require("../parser");
 const { questionsLogin } = require("../questions");
-const { accountCreateEmailSession, accountDeleteSession } = require("./account");
+const { accountCreateEmailPasswordSession, accountDeleteSession } = require("./account");
 
 const login = new Command("login")
     .description(commandDescriptions['login'])
@@ -17,7 +17,7 @@ const login = new Command("login")
 
         let client = await sdkForConsole(false);
 
-        await accountCreateEmailSession({
+        await accountCreateEmailPasswordSession({
             email: answers.email,
             password: answers.password,
             parseOutput: false,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes the error `Error accountCreateEmailSession is not a function` when running `appwrite login`

## Test Plan

Tested logging into self-hosted appwrite instance successfully.

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

Issue #116 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes