### PR TITLE
Create Organisation using CLI

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -11,7 +11,7 @@ const { storageListBuckets } = require("./storage");
 const { sdkForConsole } = require("../sdks");
 const { localConfig } = require("../config");
 const { paginate } = require("../paginate");
-const { questionsInitProject, questionsInitFunction, questionsInitCollection } = require("../questions");
+const { questionsInitProject, questionsInitTeams, questionsInitFunction, questionsInitCollection } = require("../questions");
 const { success, log, actionRunner, commandDescriptions } = require("../parser");
 
 const init = new Command("init")
@@ -222,16 +222,32 @@ const initBucket = async () => {
 }
 
 const initTeam = async () => {
-    const { teams } = await paginate(teamsList, { parseOutput: false }, 100, 'teams');
+    let response = {}
+    const answers = await inquirer.prompt(questionsInitTeams)
+    if (!answers.team) process.exit(1)
 
-    log(`Found ${teams.length} teams`);
+    let sdk = await sdkForConsole();
 
-    teams.forEach(async team => {
-        log(`Fetching ${team.name} ...`);
-        const { total, $updatedAt, $createdAt, prefs, ...rest } = team;
-        localConfig.addTeam(rest);
-    });
+    if (answers.start === "new"){
+        response = await teamsCreate({
+            teamId: 'unique()',
+            name: answers.team,
+            sdk,
+            parseOutput: false
+        })
 
+        localConfig.addTeam(response['$id'], response.name);
+    }else{
+        const { teams } = await paginate(teamsList, { parseOutput: false }, 100, 'teams');
+
+        log(`Found ${teams.length} teams`);
+    
+        teams.forEach(async team => {
+            log(`Fetching ${team.name} ...`);
+            const { total, $updatedAt, $createdAt, prefs, ...rest } = team;
+            localConfig.addTeam(rest);
+        });
+    }
     success();
 }
 

--- a/lib/questions.js
+++ b/lib/questions.js
@@ -1,4 +1,5 @@
 const { localConfig } = require('./config');
+const { teamsList } = require('./commands/teams');
 const { projectsList } = require('./commands/projects');
 const { functionsListRuntimes } = require('./commands/functions');
 const { accountListMfaFactors } = require("./commands/account");
@@ -372,6 +373,71 @@ const questionsGetEntrypoint = [
     },
 ]
 
+const questionsInitTeams = [
+    {
+        type: "list",
+        name: "start",
+        message: "Would you like to create a new organization?",
+        choices: [
+            {
+                name: "Create a new Appwrite organization",
+                value: "new",
+            },
+            {
+                name: "Link this directory to an existing Appwrite organization",
+                value: "existing"
+            }
+        ],
+    },
+    {
+        type: "input",
+        name: "name",
+        message: "What would you like to name your organization?",
+        default: "My Awesome Organization",
+        when(answers) {
+            return answers.start == "new";
+        },
+    },
+    {
+        type: "input",
+        name: "id",
+        message: "What ID would like to have for your organization?",
+        default: "unique()",
+        when(answers) {
+            return answers.start == "new";
+        }
+    },
+    {
+        type: "list",
+        name: "organization",
+        message: "Choose your Appwrite organization.",
+        when(answers) {
+            return answers.start == "existing";
+        },
+        choices: async () => {
+            let response = await teamsList({
+                parseOutput: false
+            })
+            let teams = response["teams"]
+            let choices = teams.map((team, idx) => {
+                return {
+                    name: `${team.name} (${team['$id']})`,
+                    value: {
+                        name: team.name,
+                        id: team['$id']
+                    }
+                }
+            })
+
+            if (choices.length == 0){
+                throw new Error("No organization found. Please create a new organization")
+            }
+
+            return choices;
+        }
+    },
+]
+
 const questionsDeployTeams = [
     {
         type: "checkbox",
@@ -453,6 +519,7 @@ module.exports = {
     questionsLogin,
     questionsInitFunction,
     questionsInitCollection,
+    questionsInitTeams,
     questionsDeployFunctions,
     questionsDeployCollections,
     questionsDeployBuckets,


### PR DESCRIPTION
Creates Organisation using CLI
- update initTeam method to incoporate questionsInitteams.
- Add prompts to questionsInitTeams to create new organization or choose from existing organization

## What does this PR do?

Create organization using CLI commands
Fixes #130 

## Test Plan

X

## Related PRs and Issues

- https://github.com/appwrite/sdk-for-cli/issues/130

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes