### PR TITLE
WIP - Update python startCommand

### DIFF
--- a/lib/emulation/utils.js
+++ b/lib/emulation/utils.js
@@ -40,7 +40,7 @@ const systemTools = {
     },
     'python': {
         isCompiled: false,
-        startCommand: "python3 src/server.py",
+        startCommand: "helpers/server.sh",
         dependencyFiles: [ "requirements.txt", "requirements.lock" ]
     },
     'python-ml': {


### PR DESCRIPTION
Change python startCommand to align with latest version of openruntime

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Changes the start command for python to run the server using the helper script that's available in the latest version of open runtime.

## Test Plan

- Tested locally with python function

## Related PRs and Issues

- https://github.com/appwrite/appwrite/issues/9162

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes