### PR TITLE
feat: Add multi-region support to init command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,61 @@
+# Change Log
+
+## 8.1.0
+
+* Add multi-region support to `init` command
+* Update `init` command to clear previous configuration in `appwrite.json`
+* Update localConfig to store multi-region endpoint
+* Fix throw error when creating unknown attribute instead of timing out
+* Fix equal comparison of large numbers and BigNumber instances using proper equality checks
+* Fix duplication of reasons when comparing localConfig with remoteConfig
+* Fix `firstOrNull()` to `firstOrNull` in types generation for dart
+* Refactor to use `isCloud()` method consistently
+
+## 8.0.2
+
+* Add Type generation fixes:
+  * Properly handle enum attributes in dart, java and kotlin
+  * Fix initialisation of null attributes in dart&#039;s fromMap method
+  * Fix relationships and enums in swift
+
+## 8.0.1
+
+* Add `resourceId` and `resourceType` attributes to `createRedirectRule`
+* Add `providerReference` to vcs command for getting repository contents
+* Add warning comment to `bulk updateDocuments` method
+* Fix type generation for enums in Typescript and PHP language
+
+## 8.0.0
+
+* Add `types` command to generate language specific typings for collections. Currently supports - `php`, `swift`, `dart`, `js`, `ts`, `kotlin` and `java`
+* Update bulk operation docs to include experiment feature warnings
+* Remove assistant service and commands
+
+## 7.0.0
+
+* Add `sites` command
+* Add `tokens` command
+* Add `devKeys` support to `projects` command
+* Add `init site`, `pull site` and `push site` commands
+* Add bulk operation methods like `createDocuments`, `deleteDocuments` etc.
+* Add new upsert methods: `upsertDocument` and `upsertDocuments`
+* Update GET requests to not include content-type header
+
+## 6.2.3
+
+* Fix hot swapping error in `python-ml` function
+
+## 6.2.2
+
+* Fix GitHub builds by adding `qemu-system` package
+* Fix attribute creation timed out
+
+## 6.2.1
+
+* Add `listOrganizations` method to `organizations` service and fix init project command
+
+## 6.2.0
+
+* Add specifications support to CLI
+* Update package version
+* Fix: Missed specifications param when updating a function

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Once the installation is complete, you can verify the install using
 
 ```sh
 $ appwrite -v
-8.0.2
+8.1.0
 ```
 
 ### Install using prebuilt binaries
@@ -60,7 +60,7 @@ $ scoop install https://raw.githubusercontent.com/appwrite/sdk-for-cli/master/sc
 Once the installation completes, you can verify your install using
 ```
 $ appwrite -v
-8.0.2
+8.1.0
 ```
 
 ## Getting Started 

--- a/install.ps1
+++ b/install.ps1
@@ -13,8 +13,8 @@
 # You can use "View source" of this page to see the full script.
 
 # REPO
-$GITHUB_x64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/8.0.2/appwrite-cli-win-x64.exe"
-$GITHUB_arm64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/8.0.2/appwrite-cli-win-arm64.exe"
+$GITHUB_x64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/8.1.0/appwrite-cli-win-x64.exe"
+$GITHUB_arm64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/8.1.0/appwrite-cli-win-arm64.exe"
 
 $APPWRITE_BINARY_NAME = "appwrite.exe"
 

--- a/install.sh
+++ b/install.sh
@@ -97,7 +97,7 @@ printSuccess() {
 downloadBinary() {
     echo "[2/4] Downloading executable for $OS ($ARCH) ..."
 
-    GITHUB_LATEST_VERSION="8.0.2"
+    GITHUB_LATEST_VERSION="8.1.0"
     GITHUB_FILE="appwrite-cli-${OS}-${ARCH}"
     GITHUB_URL="https://github.com/$GITHUB_REPOSITORY_NAME/releases/download/$GITHUB_LATEST_VERSION/$GITHUB_FILE"
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -16,8 +16,8 @@ class Client {
       'x-sdk-name': 'Command Line',
       'x-sdk-platform': 'console',
       'x-sdk-language': 'cli',
-      'x-sdk-version': '8.0.2',
-      'user-agent' : `AppwriteCLI/8.0.2 (${os.type()} ${os.version()}; ${os.arch()})`,
+      'x-sdk-version': '8.1.0',
+      'user-agent' : `AppwriteCLI/8.1.0 (${os.type()} ${os.version()}; ${os.arch()})`,
       'X-Appwrite-Response-Format' : '1.7.0',
     };
   }

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -28,6 +28,7 @@ const { cliConfig, success, log, hint, error, actionRunner, commandDescriptions 
 const { accountGet } = require("./account");
 const { sitesListTemplates } = require("./sites");
 const { sdkForConsole } = require("../sdks");
+const { isCloud } = require('../utils');
 
 const initResources = async () => {
     const actions = {
@@ -94,6 +95,9 @@ const initProject = async ({ organizationId, projectId, projectName } = {}) => {
         }
     }
 
+    localConfig.clear(); // Clear the config to avoid any conflicts
+    const url = new URL("https://cloud.appwrite.io/v1");
+    
     if (answers.start === 'new') {
         response = await projectsCreate({
             projectId: answers.id,
@@ -103,8 +107,14 @@ const initProject = async ({ organizationId, projectId, projectName } = {}) => {
         })
 
         localConfig.setProject(response['$id']);
+        if (answers.region) {
+            localConfig.setEndpoint(`https://${answers.region}.${url.host}${url.pathname}`);
+        }
     } else {
-        localConfig.setProject(answers.project);
+        localConfig.setProject(answers.project["$id"]);
+        if(isCloud()) {
+            localConfig.setEndpoint(`https://${answers.project["region"]}.${url.host}${url.pathname}`);
+        }
     }
 
     success(`Project successfully ${answers.start === 'existing' ? 'linked' : 'created'}. Details are now stored in appwrite.json file.`);

--- a/lib/config.js
+++ b/lib/config.js
@@ -150,6 +150,14 @@ class Local extends Config {
         return _path.dirname(this.path)
     }
 
+    getEndpoint() {
+        return this.get('endpoint') || '';
+    }
+
+    setEndpoint(endpoint) {
+        this.set('endpoint', endpoint);
+    }
+
     getSites() {
         if (!this.has("sites")) {
             return [];

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -5,6 +5,7 @@ const { description } = require('../package.json');
 const { globalConfig } = require("./config.js");
 const os = require('os');
 const Client = require("./client");
+const { isCloud } = require("./utils");
 
 const cliConfig = {
     verbose: false,
@@ -111,7 +112,6 @@ const parseError = (err) => {
         (async () => {
             let appwriteVersion = 'unknown';
             const endpoint = globalConfig.getEndpoint();
-            const isCloud = endpoint.includes('cloud.appwrite.io') ? 'Yes' : 'No';
 
             try {
                 const client = new Client().setEndpoint(endpoint);
@@ -120,9 +120,9 @@ const parseError = (err) => {
             } catch {
             }
 
-            const version = '8.0.2';
+            const version = '8.1.0';
             const stepsToReproduce = `Running \`appwrite ${cliConfig.reportData.data.args.join(' ')}\``;
-            const yourEnvironment = `CLI version: ${version}\nOperation System: ${os.type()}\nAppwrite version: ${appwriteVersion}\nIs Cloud: ${isCloud}`;
+            const yourEnvironment = `CLI version: ${version}\nOperation System: ${os.type()}\nAppwrite version: ${appwriteVersion}\nIs Cloud: ${isCloud()}`;
 
             const stack = '```\n' + err.stack + '\n```';
 

--- a/lib/sdks.js
+++ b/lib/sdks.js
@@ -23,7 +23,7 @@ const sdkForConsole = async (requiresAuth = true) => {
 
 const sdkForProject = async () => {
   let client = new Client();
-  let endpoint = globalConfig.getEndpoint();
+  let endpoint = localConfig.getEndpoint() || globalConfig.getEndpoint();
   let project = localConfig.getProject().projectId ? localConfig.getProject().projectId : globalConfig.getProject();
   let key = globalConfig.getKey();
   let cookie = globalConfig.getCookie()

--- a/lib/type-generation/attribute.js
+++ b/lib/type-generation/attribute.js
@@ -1,7 +1,7 @@
 const AttributeType = {
     STRING: "string",
     INTEGER: "integer",
-    FLOAT: "float",
+    FLOAT: "double",
     BOOLEAN: "boolean",
     DATETIME: "datetime",
     EMAIL: "email",

--- a/lib/type-generation/languages/dart.js
+++ b/lib/type-generation/languages/dart.js
@@ -78,7 +78,7 @@ class <%= toPascalCase(collection.name) %> {
 (map['<%= attribute.key %>'] as List<dynamic>?)?.map((e) => <%- toPascalCase(attribute.key) %>.values.firstWhere((element) => element.name == e)).toList()<% if (!attribute.required) { %> ?? []<% } -%>
 <% } else { -%>
 <% if (!attribute.required) { -%>
-map['<%= attribute.key %>'] != null ? <%- toPascalCase(attribute.key) %>.values.where((e) => e.name == map['<%= attribute.key %>']).firstOrNull() : null<% } else { -%>
+map['<%= attribute.key %>'] != null ? <%- toPascalCase(attribute.key) %>.values.where((e) => e.name == map['<%= attribute.key %>']).firstOrNull : null<% } else { -%>
 <%- toPascalCase(attribute.key) %>.values.firstWhere((e) => e.name == map['<%= attribute.key %>'])<% } -%>
 <% } -%>
 <% } else { -%>

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -274,10 +274,17 @@ function getUsersPath(action, ids) {
     return path;
 }
 
+function isCloud() {
+    const endpoint = globalConfig.getEndpoint() || "https://cloud.appwrite.io/v1";
+    const hostname = new URL(endpoint).hostname;
+    return hostname.endsWith('appwrite.io');
+}
+
 module.exports = {
     getAllFiles,
     isPortTaken,
     systemHasCommand,
     checkDeployConditions,
-    showConsoleLink
+    showConsoleLink,
+    isCloud
 };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "appwrite-cli",
   "homepage": "https://appwrite.io/support",
   "description": "Appwrite is an open-source self-hosted backend server that abstract and simplify complex and repetitive development tasks behind a very simple REST API",
-  "version": "8.0.2",
+  "version": "8.1.0",
   "license": "BSD-3-Clause",
   "main": "index.js",
   "bin": {

--- a/scoop/appwrite.json
+++ b/scoop/appwrite.json
@@ -1,12 +1,12 @@
 {
 	"$schema": "https://raw.githubusercontent.com/ScoopInstaller/Scoop/master/schema.json",
-	"version": "8.0.2",
+	"version": "8.1.0",
 	"description": "The Appwrite CLI is a command-line application that allows you to interact with Appwrite and perform server-side tasks using your terminal.",
 	"homepage": "https://github.com/appwrite/sdk-for-cli",
 	"license": "BSD-3-Clause",
 	"architecture": {
 		"64bit": {
-			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/8.0.2/appwrite-cli-win-x64.exe",
+			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/8.1.0/appwrite-cli-win-x64.exe",
 			"bin": [
 				[
 					"appwrite-cli-win-x64.exe",
@@ -15,7 +15,7 @@
 			]
 		},
 		"arm64": {
-			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/8.0.2/appwrite-cli-win-arm64.exe",
+			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/8.1.0/appwrite-cli-win-arm64.exe",
 			"bin": [
 				[
 					"appwrite-cli-win-arm64.exe",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

* Add multi-region support to `init` command
* Update `init` command to clear previous configuration in `appwrite.json`
* Update localConfig to store multi-region endpoint
* Fix throw error when creating unknown attribute instead of timing out
* Fix equal comparison of large numbers and BigNumber instances using proper equality checks
* Fix duplication of reasons when comparing localConfig with remoteConfig
* Fix `firstOrNull()` to `firstOrNull` in types generation for dart
* Refactor to use `isCloud()` method consistently

## Test Plan

## Related PRs and Issues

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes.