### PR TITLE
fix: improve error message when node-appwrite is missing in monorepo setups 

### DIFF
--- a/lib/type-generation/languages/typescript.js
+++ b/lib/type-generation/languages/typescript.js
@@ -51,18 +51,38 @@ class TypeScript extends LanguageMeta {
   }
 
   _getAppwriteDependency() {
-    if (fs.existsSync(path.resolve(process.cwd(), 'package.json'))) {
-      const packageJsonRaw = fs.readFileSync(path.resolve(process.cwd(), 'package.json'));
-      const packageJson = JSON.parse(packageJsonRaw.toString('utf-8'));
-      return packageJson.dependencies['node-appwrite'] ? 'node-appwrite' : 'appwrite';
-    }
+  const packageJsonPath = path.resolve(process.cwd(), 'package.json');
 
-    if (fs.existsSync(path.resolve(process.cwd(), 'deno.json'))) {
-      return "https://deno.land/x/appwrite/mod.ts";
-    }
+  if (fs.existsSync(packageJsonPath)) {
+    try {
+      const packageJsonRaw = fs.readFileSync(packageJsonPath, 'utf-8');
+      const packageJson = JSON.parse(packageJsonRaw);
 
-    return "appwrite";
+      const deps = {
+        ...packageJson.dependencies,
+        ...packageJson.devDependencies,
+      };
+
+      if (deps['node-appwrite']) return 'node-appwrite';
+      if (deps['appwrite']) return 'appwrite';
+
+      throw new Error(
+        `❌ Could not find 'node-appwrite' or 'appwrite' in package.json.\n` +
+        `👉 If you're using a monorepo, try running the CLI from your project root\n` +
+        `or ensure 'node-appwrite' is listed in your dependencies.`
+      );
+    } catch (err) {
+      throw new Error(`❌ Failed to read or parse package.json: ${err.message}`);
+    }
   }
+
+  if (fs.existsSync(path.resolve(process.cwd(), 'deno.json'))) {
+    return "https://deno.land/x/appwrite/mod.ts";
+  }
+
+  return "appwrite";
+}
+
 
   getCurrentDirectory() {
     return process.cwd();


### PR DESCRIPTION
## 🐛 Fixes

Fixes #10131

## ✨ Summary

This PR improves the error handling in the `appwrite types` command when the CLI is unable to find `node-appwrite` or `appwrite` in the `package.json`.

Previously, the CLI would throw a `TypeError: Cannot read properties of undefined (reading 'node-appwrite')`. This PR replaces that with a clearer, user-friendly error message that:

- Explains why the error occurs
- Suggests running the CLI from the project root
- Mentions monorepo support and dependencies

## 🔍 Changes Made

- Modified `_getAppwriteDependency()` in `sdk-for-cli/lib/type-generation/languages/typescript.js`
- Added:
  - Null checks for `dependencies` and `devDependencies`
  - Custom error messages for missing dependencies
  - JSON parse error handling for corrupted `package.json`

## 🧪 How to Test

Run:

```bash
node ./bin/appwrite.js types ./output --language=ts --verbose

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)