### PR TITLE
chore: regenerate sdk

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -41,7 +41,7 @@ jobs:
             npm publish
           fi
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_NO_ORG }}
       - uses: fnkr/github-action-ghr@v1
         env:
           GHR_PATH: build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 8.2.1
+
+* Added `--with-variables` option to the Sites command for adding/updating environment variables  
+* Fixed Functions environment variables not being pushed with `--with-variables`  
+* Removed `awaitPools` when wiping old variables  
+
+> **Note:** Storing environment variables in the `vars` attribute of `appwrite.json` is now deprecated due to security risks. Variables are now synced directly from the `.env` file in the root directory of the function’s or site’s folder.
+
 ## 8.2.0
 
 * Add `encrypt` attribute support

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Once the installation is complete, you can verify the install using
 
 ```sh
 $ appwrite -v
-8.2.0
+8.2.1
 ```
 
 ### Install using prebuilt binaries
@@ -60,7 +60,7 @@ $ scoop install https://raw.githubusercontent.com/appwrite/sdk-for-cli/master/sc
 Once the installation completes, you can verify your install using
 ```
 $ appwrite -v
-8.2.0
+8.2.1
 ```
 
 ## Getting Started 

--- a/install.ps1
+++ b/install.ps1
@@ -13,8 +13,8 @@
 # You can use "View source" of this page to see the full script.
 
 # REPO
-$GITHUB_x64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/8.2.0/appwrite-cli-win-x64.exe"
-$GITHUB_arm64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/8.2.0/appwrite-cli-win-arm64.exe"
+$GITHUB_x64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/8.2.1/appwrite-cli-win-x64.exe"
+$GITHUB_arm64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/8.2.1/appwrite-cli-win-arm64.exe"
 
 $APPWRITE_BINARY_NAME = "appwrite.exe"
 

--- a/install.sh
+++ b/install.sh
@@ -97,7 +97,7 @@ printSuccess() {
 downloadBinary() {
     echo "[2/4] Downloading executable for $OS ($ARCH) ..."
 
-    GITHUB_LATEST_VERSION="8.2.0"
+    GITHUB_LATEST_VERSION="8.2.1"
     GITHUB_FILE="appwrite-cli-${OS}-${ARCH}"
     GITHUB_URL="https://github.com/$GITHUB_REPOSITORY_NAME/releases/download/$GITHUB_LATEST_VERSION/$GITHUB_FILE"
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -16,8 +16,8 @@ class Client {
       'x-sdk-name': 'Command Line',
       'x-sdk-platform': 'console',
       'x-sdk-language': 'cli',
-      'x-sdk-version': '8.2.0',
-      'user-agent' : `AppwriteCLI/8.2.0 (${os.type()} ${os.version()}; ${os.arch()})`,
+      'x-sdk-version': '8.2.1',
+      'user-agent' : `AppwriteCLI/8.2.1 (${os.type()} ${os.version()}; ${os.arch()})`,
       'X-Appwrite-Response-Format' : '1.7.0',
     };
   }

--- a/lib/commands/push.js
+++ b/lib/commands/push.js
@@ -1,3 +1,6 @@
+const fs = require('fs');
+const path = require('path');
+const { parse: parseDotenv } = require('dotenv');
 const chalk = require('chalk');
 const inquirer = require("inquirer");
 const JSONbig = require("json-bigint")({ storeAsString: false });
@@ -12,7 +15,7 @@ const { proxyCreateFunctionRule, proxyCreateSiteRule, proxyListRules } = require
 const { consoleVariables } = require('./console');
 const { sdkForConsole } = require('../sdks')
 const { functionsGet, functionsCreate, functionsUpdate, functionsCreateDeployment, functionsGetDeployment, functionsListVariables, functionsDeleteVariable, functionsCreateVariable } = require('./functions');
-const { sitesGet, sitesCreate, sitesUpdate, sitesCreateDeployment, sitesGetDeployment, sitesCreateVariable } = require('./sites');
+const { sitesGet, sitesCreate, sitesUpdate, sitesCreateDeployment, sitesGetDeployment, sitesCreateVariable, sitesListVariables, sitesDeleteVariable } = require('./sites');
 const {
     databasesGet,
     databasesCreate,
@@ -146,37 +149,6 @@ const awaitPools = {
         return await awaitPools.wipeIndexes(
             databaseId,
             collectionId,
-            iteration + 1
-        );
-    },
-    wipeVariables: async (functionId, iteration = 1) => {
-        if (iteration > pollMaxDebounces) {
-            return false;
-        }
-
-        const { total } = await functionsListVariables({
-            functionId,
-            queries: ['limit(1)'],
-            parseOutput: false
-        });
-
-        if (total === 0) {
-            return true;
-        }
-
-        if (pollMaxDebounces === POLL_DEFAULT_VALUE) {
-            let steps = Math.max(1, Math.ceil(total / STEP_SIZE));
-            if (steps > 1 && iteration === 1) {
-                pollMaxDebounces *= steps;
-
-                log('Found a large number of variables, increasing timeout to ' + (pollMaxDebounces * POLL_DEBOUNCE / 1000 / 60) + ' minutes')
-            }
-        }
-
-        await new Promise(resolve => setTimeout(resolve, POLL_DEBOUNCE));
-
-        return await awaitPools.wipeVariables(
-            functionId,
             iteration + 1
         );
     },
@@ -1047,7 +1019,7 @@ const pushSettings = async () => {
     }
 }
 
-const pushSite = async({ siteId, async, code } = { returnOnZero: false }) => {
+const pushSite = async({ siteId, async, code, withVariables } = { returnOnZero: false }) => {
     process.chdir(localConfig.configDirectoryPath)
 
     const siteIds = [];
@@ -1180,7 +1152,6 @@ const pushSite = async({ siteId, async, code } = { returnOnZero: false }) => {
                     timeout: site.timeout,
                     enabled: site.enabled,
                     logging: site.logging,
-                    vars: JSON.stringify(site.vars),
                     parseOutput: false
                 });
 
@@ -1213,16 +1184,43 @@ const pushSite = async({ siteId, async, code } = { returnOnZero: false }) => {
             }
         }
 
-        updaterRow.update({ status: 'Creating variables' }).replaceSpinner(SPINNER_ARC);
+        if (withVariables) {
+            updaterRow.update({ status: 'Creating variables' }).replaceSpinner(SPINNER_ARC);
 
-        await Promise.all((site['vars'] ?? []).map(async variable => {
-            await sitesCreateVariable({
+            const { variables } = await paginate(sitesListVariables, {
                 siteId: site['$id'],
-                key: variable['key'],
-                value: variable['value'],
                 parseOutput: false
-            });
-        }));
+            }, 100, 'variables');
+
+            await Promise.all(variables.map(async variable => {
+                await sitesDeleteVariable({
+                    siteId: site['$id'],
+                    variableId: variable['$id'],
+                    parseOutput: false
+                });
+            }));
+
+            const envFileLocation = `${site['path']}/.env`;
+            let envVariables = [];
+            try {
+                if (fs.existsSync(envFileLocation)) {
+                    const envObject = parseDotenv(fs.readFileSync(envFileLocation, 'utf8'));
+                    envVariables = Object.entries(envObject || {}).map(([key, value]) => ({ key, value }));
+                }
+            } catch (error) {
+                // Handle parsing errors gracefully
+                envVariables = [];
+            }
+            await Promise.all(envVariables.map(async variable => {
+                await sitesCreateVariable({
+                    siteId: site['$id'],
+                    key: variable.key,
+                    value: variable.value,
+                    parseOutput: false,
+                    secret: false
+                });
+            }));
+        }
 
         if (code === false) {
             successfullyPushed++;
@@ -1475,7 +1473,6 @@ const pushFunction = async ({ functionId, async, code, withVariables } = { retur
                     entrypoint: func.entrypoint,
                     commands: func.commands,
                     scopes: func.scopes,
-                    vars: JSON.stringify(func.vars),
                     parseOutput: false
                 });
 
@@ -1524,19 +1521,25 @@ const pushFunction = async ({ functionId, async, code, withVariables } = { retur
                 });
             }));
 
-            let result = await awaitPools.wipeVariables(func['$id']);
-            if (!result) {
-                updaterRow.fail({ errorMessage: `Variable deletion timed out.` })
-                return;
+            const envFileLocation = `${func['path']}/.env`;
+            let envVariables = [];
+            try {
+                if (fs.existsSync(envFileLocation)) {
+                    const envObject = parseDotenv(fs.readFileSync(envFileLocation, 'utf8'));
+                    envVariables = Object.entries(envObject || {}).map(([key, value]) => ({ key, value }));
+                }
+            } catch (error) {
+                // Handle parsing errors gracefully
+                envVariables = [];
             }
-
-            // Deploy local variables
-            await Promise.all((func['vars'] ?? []).map(async variable => {
+            await Promise.all(envVariables.map(async variable => {
                 await functionsCreateVariable({
                     functionId: func['$id'],
-                    key: variable['key'],
-                    value: variable['value'],
-                    parseOutput: false
+                    variableId: ID.unique(),
+                    key: variable.key,
+                    value: variable.value,
+                    parseOutput: false,
+                    secret: false
                 });
             }));
         }
@@ -2065,6 +2068,7 @@ push
     .option(`-f, --site-id <site-id>`, `ID of site to run`)
     .option(`-A, --async`, `Don't wait for sites deployments status`)
     .option("--no-code", "Don't push the site's code")
+    .option("--with-variables", `Push site variables.`)
     .action(actionRunner(pushSite));
 
 push

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -122,7 +122,7 @@ const parseError = (err) => {
             } catch {
             }
 
-            const version = '8.2.0';
+            const version = '8.2.1';
             const stepsToReproduce = `Running \`appwrite ${cliConfig.reportData.data.args.join(' ')}\``;
             const yourEnvironment = `CLI version: ${version}\nOperation System: ${os.type()}\nAppwrite version: ${appwriteVersion}\nIs Cloud: ${isCloud()}`;
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "appwrite-cli",
   "homepage": "https://appwrite.io/support",
   "description": "Appwrite is an open-source self-hosted backend server that abstract and simplify complex and repetitive development tasks behind a very simple REST API",
-  "version": "8.2.0",
+  "version": "8.2.1",
   "license": "BSD-3-Clause",
   "main": "index.js",
   "bin": {

--- a/scoop/appwrite.json
+++ b/scoop/appwrite.json
@@ -1,12 +1,12 @@
 {
 	"$schema": "https://raw.githubusercontent.com/ScoopInstaller/Scoop/master/schema.json",
-	"version": "8.2.0",
+	"version": "8.2.1",
 	"description": "The Appwrite CLI is a command-line application that allows you to interact with Appwrite and perform server-side tasks using your terminal.",
 	"homepage": "https://github.com/appwrite/sdk-for-cli",
 	"license": "BSD-3-Clause",
 	"architecture": {
 		"64bit": {
-			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/8.2.0/appwrite-cli-win-x64.exe",
+			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/8.2.1/appwrite-cli-win-x64.exe",
 			"bin": [
 				[
 					"appwrite-cli-win-x64.exe",
@@ -15,7 +15,7 @@
 			]
 		},
 		"arm64": {
-			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/8.2.0/appwrite-cli-win-arm64.exe",
+			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/8.2.1/appwrite-cli-win-arm64.exe",
 			"bin": [
 				[
 					"appwrite-cli-win-arm64.exe",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

* Added `--with-variables` option to the Sites command for adding/updating environment variables  
* Fixed Functions environment variables not being pushed with `--with-variables`  
* Removed `awaitPools` when wiping old variables  

> **Note:** Storing environment variables in the `vars` attribute of `appwrite.json` is now deprecated due to security risks. Variables are now synced directly from the `.env` file in the root directory of the function’s or site’s folder.

## Test Plan

## Related PRs and Issues

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes.