### PR TITLE
chore: regenerate sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## 8.2.2
+
+* Fix object comparison logic when pushing settings
+* Type generation fixes:
+   * Dart: Fixed import casing to snake_case, removed `extends Document` and hardcoded attributes, removed unnecessary imports
+   * Java: Fixed indentation to 4 spaces, updated imports to `java.util.Objects`, fixed enum casing in strict mode as per [Oracle official docs](https://docs.oracle.com/javase/tutorial/java/javaOO/enum.html)
+   * Javascript: Updated optional values formatting from `|null` to `| null`
+   * Kotlin: Fixed indentation to 4 spaces per [Kotlinlang official docs](https://kotlinlang.org/docs/coding-conventions.html#indentation)
+   * PHP: Fixed indentation to 4 spaces per [PHP Fig official docs](https://www.php-fig.org/psr/psr-2/)
+   * Swift: Fixed indentation to 4 spaces, improved `decodeIfPresent` usage for optionals, added missing `public` to `init` method
+   * Typescript: Fixed indentation to 4 spaces per [Typescript coding guidelines](https://github.com/microsoft/TypeScript/wiki/Coding-guidelines)
+
 ## 8.2.1
 
 * Added `--with-variables` option to the Sites command for adding/updating environment variables  

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Once the installation is complete, you can verify the install using
 
 ```sh
 $ appwrite -v
-8.2.1
+8.2.2
 ```
 
 ### Install using prebuilt binaries
@@ -60,7 +60,7 @@ $ scoop install https://raw.githubusercontent.com/appwrite/sdk-for-cli/master/sc
 Once the installation completes, you can verify your install using
 ```
 $ appwrite -v
-8.2.1
+8.2.2
 ```
 
 ## Getting Started 

--- a/install.ps1
+++ b/install.ps1
@@ -13,8 +13,8 @@
 # You can use "View source" of this page to see the full script.
 
 # REPO
-$GITHUB_x64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/8.2.1/appwrite-cli-win-x64.exe"
-$GITHUB_arm64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/8.2.1/appwrite-cli-win-arm64.exe"
+$GITHUB_x64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/8.2.2/appwrite-cli-win-x64.exe"
+$GITHUB_arm64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/8.2.2/appwrite-cli-win-arm64.exe"
 
 $APPWRITE_BINARY_NAME = "appwrite.exe"
 

--- a/install.sh
+++ b/install.sh
@@ -97,7 +97,7 @@ printSuccess() {
 downloadBinary() {
     echo "[2/4] Downloading executable for $OS ($ARCH) ..."
 
-    GITHUB_LATEST_VERSION="8.2.1"
+    GITHUB_LATEST_VERSION="8.2.2"
     GITHUB_FILE="appwrite-cli-${OS}-${ARCH}"
     GITHUB_URL="https://github.com/$GITHUB_REPOSITORY_NAME/releases/download/$GITHUB_LATEST_VERSION/$GITHUB_FILE"
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -16,8 +16,8 @@ class Client {
       'x-sdk-name': 'Command Line',
       'x-sdk-platform': 'console',
       'x-sdk-language': 'cli',
-      'x-sdk-version': '8.2.1',
-      'user-agent' : `AppwriteCLI/8.2.1 (${os.type()} ${os.version()}; ${os.arch()})`,
+      'x-sdk-version': '8.2.2',
+      'user-agent' : `AppwriteCLI/8.2.2 (${os.type()} ${os.version()}; ${os.arch()})`,
       'X-Appwrite-Response-Format' : '1.7.0',
     };
   }

--- a/lib/commands/push.js
+++ b/lib/commands/push.js
@@ -417,8 +417,17 @@ const getObjectChanges = (remote, local, index, what) => {
 
     if (remote[index] && local[index]) {
         for (let [service, status] of Object.entries(remote[index])) {
-            if (status !== local[index][service]) {
-                changes.push({ group: what, setting: service, remote: chalk.red(status), local: chalk.green(local[index][service]) })
+            const localValue = local[index][service];
+            let valuesEqual = false;
+
+            if (Array.isArray(status) && Array.isArray(localValue)) {
+                valuesEqual = JSON.stringify(status) === JSON.stringify(localValue);
+            } else {
+                valuesEqual = status === localValue;
+            }
+            
+            if (!valuesEqual) {
+                changes.push({ group: what, setting: service, remote: chalk.red(status), local: chalk.green(localValue) })
             }
         }
     }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -122,7 +122,7 @@ const parseError = (err) => {
             } catch {
             }
 
-            const version = '8.2.1';
+            const version = '8.2.2';
             const stepsToReproduce = `Running \`appwrite ${cliConfig.reportData.data.args.join(' ')}\``;
             const yourEnvironment = `CLI version: ${version}\nOperation System: ${os.type()}\nAppwrite version: ${appwriteVersion}\nIs Cloud: ${isCloud()}`;
 

--- a/lib/type-generation/languages/dart.js
+++ b/lib/type-generation/languages/dart.js
@@ -83,10 +83,9 @@ class Dart extends LanguageMeta {
   }
 
   getTemplate() {
-    return `import 'package:${this.getPackageName()}/models.dart';
-<% for (const attribute of collection.attributes) { -%>
+    return `<% for (const attribute of collection.attributes) { -%>
 <% if (attribute.type === 'relationship') { -%>
-import '<%- attribute.relatedCollection.toLowerCase() %>.dart';
+import '<%- toSnakeCase(attribute.relatedCollection) %>.dart';
 
 <% } -%>
 <% } -%>
@@ -103,19 +102,12 @@ enum <%- toPascalCase(attribute.key) %> {
 
 <% } -%>
 <% } -%>
-class <%= toPascalCase(collection.name) %> extends Document {
+class <%= toPascalCase(collection.name) %> {
 <% for (const [index, attribute] of Object.entries(collection.attributes)) { -%>
   <%- getType(attribute) %> <%= strict ? toCamelCase(attribute.key) : attribute.key %>;
 <% } -%>
 
   <%= toPascalCase(collection.name) %>({
-    required super.$id,
-    required super.$collectionId,
-    required super.$databaseId,
-    required super.$createdAt,
-    required super.$updatedAt,
-    required super.$permissions,
-    required super.data,
   <% for (const [index, attribute] of Object.entries(collection.attributes)) { -%>
   <% if (attribute.required) { %>required <% } %>this.<%= strict ? toCamelCase(attribute.key) : attribute.key %><% if (index < collection.attributes.length - 1) { %>,<% } %>
   <% } -%>
@@ -123,13 +115,6 @@ class <%= toPascalCase(collection.name) %> extends Document {
 
   factory <%= toPascalCase(collection.name) %>.fromMap(Map<String, dynamic> map) {
     return <%= toPascalCase(collection.name) %>(
-      $id: map['\\$id'].toString(),
-      $collectionId: map['\\$collectionId'].toString(),
-      $databaseId: map['\\$databaseId'].toString(),
-      $createdAt: map['\\$createdAt'].toString(),
-      $updatedAt: map['\\$updatedAt'].toString(),
-      $permissions: List<String>.from(map['\\$permissions'] ?? []),
-      data: map,
 <% for (const [index, attribute] of Object.entries(collection.attributes)) { -%>
       <%= strict ? toCamelCase(attribute.key) : attribute.key %>: <% if (attribute.type === 'string' || attribute.type === 'email' || attribute.type === 'datetime') { -%>
 <% if (attribute.format === 'enum') { -%>
@@ -180,12 +165,6 @@ map['<%= attribute.key %>'] != null ? <%- toPascalCase(attribute.relatedCollecti
 
   Map<String, dynamic> toMap() {
     return {
-      "\\$id": $id,
-      "\\$collectionId": $collectionId,
-      "\\$databaseId": $databaseId,
-      "\\$createdAt": $createdAt,
-      "\\$updatedAt": $updatedAt,
-      "\\$permissions": $permissions,
 <% for (const [index, attribute] of Object.entries(collection.attributes)) { -%>
       "<%= attribute.key %>": <% if (attribute.type === 'relationship') { -%>
 <% if ((attribute.relationType === 'oneToMany' && attribute.side === 'parent') || (attribute.relationType === 'manyToOne' && attribute.side === 'child') || attribute.relationType === 'manyToMany') { -%>

--- a/lib/type-generation/languages/java.js
+++ b/lib/type-generation/languages/java.js
@@ -50,7 +50,7 @@ class Java extends LanguageMeta {
  * You can regenerate it by running \`appwrite types -l java ${this.getCurrentDirectory()}\`.
  */
 
-import java.util.*;
+import java.util.Objects;
 <% for (const attribute of collection.attributes) { -%>
 <% if (attribute.type === 'relationship') { -%>
 import io.appwrite.models.<%- toPascalCase(attribute.relatedCollection) %>;
@@ -61,63 +61,63 @@ public class <%- toPascalCase(collection.name) %> {
 <% for (const attribute of collection.attributes) { -%>
 <% if (attribute.format === 'enum') { -%>
 
-  public enum <%- toPascalCase(attribute.key) %> {
+    public enum <%- toPascalCase(attribute.key) %> {
 <% for (const [index, element] of Object.entries(attribute.elements)) { -%>
-    <%- strict ? toSnakeCase(element) : element %><%- index < attribute.elements.length - 1 ? ',' : ';' %>
+        <%- strict ? toUpperSnakeCase(element) : element %><%- index < attribute.elements.length - 1 ? ',' : ';' %>
 <% } -%>
-  }
+    }
 
 <% } -%>
 <% } -%>
 <% for (const attribute of collection.attributes) { -%>
-  private <%- getType(attribute) %> <%- strict ? toCamelCase(attribute.key) : attribute.key %>;
+    private <%- getType(attribute) %> <%- strict ? toCamelCase(attribute.key) : attribute.key %>;
 <% } -%>
 
-  public <%- toPascalCase(collection.name) %>() {
-  }
+    public <%- toPascalCase(collection.name) %>() {
+    }
 
-  public <%- toPascalCase(collection.name) %>(
+    public <%- toPascalCase(collection.name) %>(
 <% for (const [index, attribute] of Object.entries(collection.attributes)) { -%>
-    <%- getType(attribute) %> <%= strict ? toCamelCase(attribute.key) : attribute.key %><%- index < collection.attributes.length - 1 ? ',' : '' %>
+        <%- getType(attribute) %> <%= strict ? toCamelCase(attribute.key) : attribute.key %><%- index < collection.attributes.length - 1 ? ',' : '' %>
 <% } -%>
-  ) {
+    ) {
 <% for (const attribute of collection.attributes) { -%>
-    this.<%= strict ? toCamelCase(attribute.key) : attribute.key %> = <%= strict ? toCamelCase(attribute.key) : attribute.key %>;
+        this.<%= strict ? toCamelCase(attribute.key) : attribute.key %> = <%= strict ? toCamelCase(attribute.key) : attribute.key %>;
 <% } -%>
-  }
+    }
 
 <% for (const attribute of collection.attributes) { -%>
-  public <%- getType(attribute) %> get<%- toPascalCase(attribute.key) %>() {
-    return <%= strict ? toCamelCase(attribute.key) : attribute.key %>;
-  }
+    public <%- getType(attribute) %> get<%- toPascalCase(attribute.key) %>() {
+        return <%= strict ? toCamelCase(attribute.key) : attribute.key %>;
+    }
 
-  public void set<%- toPascalCase(attribute.key) %>(<%- getType(attribute) %> <%= strict ? toCamelCase(attribute.key) : attribute.key %>) {
-    this.<%= strict ? toCamelCase(attribute.key) : attribute.key %> = <%= strict ? toCamelCase(attribute.key) : attribute.key %>;
-  }
+    public void set<%- toPascalCase(attribute.key) %>(<%- getType(attribute) %> <%= strict ? toCamelCase(attribute.key) : attribute.key %>) {
+        this.<%= strict ? toCamelCase(attribute.key) : attribute.key %> = <%= strict ? toCamelCase(attribute.key) : attribute.key %>;
+    }
 
 <% } -%>
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) return true;
-    if (obj == null || getClass() != obj.getClass()) return false;
-    <%- toPascalCase(collection.name) %> that = (<%- toPascalCase(collection.name) %>) obj;
-    return <% collection.attributes.forEach((attr, index) => { %>Objects.equals(<%= toCamelCase(attr.key) %>, that.<%= toCamelCase(attr.key) %>)<% if (index < collection.attributes.length - 1) { %> &&
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        <%- toPascalCase(collection.name) %> that = (<%- toPascalCase(collection.name) %>) obj;
+        return <% collection.attributes.forEach((attr, index) => { %>Objects.equals(<%= toCamelCase(attr.key) %>, that.<%= toCamelCase(attr.key) %>)<% if (index < collection.attributes.length - 1) { %> &&
           <% } }); %>;
-  }
+    }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(<%= collection.attributes.map(attr => toCamelCase(attr.key)).join(', ') %>);
-  }
+    @Override
+    public int hashCode() {
+        return Objects.hash(<%= collection.attributes.map(attr => toCamelCase(attr.key)).join(', ') %>);
+    }
 
-  @Override
-  public String toString() {
-    return "<%- toPascalCase(collection.name) %>{" +
-<% for (const attribute of collection.attributes) { -%>
-            "<%= strict ? toCamelCase(attribute.key) : attribute.key %>=" + <%= strict ? toCamelCase(attribute.key) : attribute.key %> +
+    @Override
+    public String toString() {
+        return "<%- toPascalCase(collection.name) %>{" +
+<% for (const [index, attribute] of Object.entries(collection.attributes)) { -%>
+                "<%= strict ? toCamelCase(attribute.key) : attribute.key %>=" + <%= strict ? toCamelCase(attribute.key) : attribute.key %> +<% if (index < collection.attributes.length - 1) { %> ", " +<% } %>
 <% } -%>
-            '}';
-  }
+                '}';
+    }
 }
 `;
   }

--- a/lib/type-generation/languages/javascript.js
+++ b/lib/type-generation/languages/javascript.js
@@ -41,7 +41,7 @@ class JavaScript extends LanguageMeta {
       type += "[]";
     }
     if (!attribute.required && attribute.default === null) {
-      type += "|null";
+      type += " | null";
     }
     return type;
   }

--- a/lib/type-generation/languages/kotlin.js
+++ b/lib/type-generation/languages/kotlin.js
@@ -63,7 +63,7 @@ import <%- toPascalCase(attribute.relatedCollection) %>
 <% if (attribute.format === 'enum') { -%>
 enum class <%- toPascalCase(attribute.key) %> {
 <% for (const [index, element] of Object.entries(attribute.elements)) { -%>
-  <%- strict ? toUpperSnakeCase(element) : element %><%- index < attribute.elements.length - 1 ? ',' : '' %>
+    <%- strict ? toUpperSnakeCase(element) : element %><%- index < attribute.elements.length - 1 ? ',' : '' %>
 <% } -%>
 }
 
@@ -71,7 +71,7 @@ enum class <%- toPascalCase(attribute.key) %> {
 <% } -%>
 data class <%- toPascalCase(collection.name) %>(
 <% for (const [index, attribute] of Object.entries(collection.attributes)) { -%>
-  val <%- strict ? toCamelCase(attribute.key) : attribute.key %>: <%- getType(attribute) %><% if (index < collection.attributes.length - 1) { %>,<% } %>
+    val <%- strict ? toCamelCase(attribute.key) : attribute.key %>: <%- getType(attribute) %><% if (index < collection.attributes.length - 1) { %>,<% } %>
 <% } -%>
 )`;
   }

--- a/lib/type-generation/languages/php.js
+++ b/lib/type-generation/languages/php.js
@@ -62,7 +62,7 @@ use Appwrite\\Models\\<%- toPascalCase(attribute.relatedCollection) %>;
 <% if (attribute.format === 'enum') { -%>
 enum <%- toPascalCase(attribute.key) %>: string {
 <% for (const [index, element] of Object.entries(attribute.elements)) { -%>
-  case <%- strict ? toUpperSnakeCase(element) : element %> = '<%- element %>';
+    case <%- strict ? toUpperSnakeCase(element) : element %> = '<%- element %>';
 <% } -%>
 }
 
@@ -70,31 +70,31 @@ enum <%- toPascalCase(attribute.key) %>: string {
 <% } -%>
 class <%- toPascalCase(collection.name) %> {
 <% for (const attribute of collection.attributes ){ -%>
-  private <%- getType(attribute) %> $<%- strict ? toCamelCase(attribute.key) : attribute.key %>;
+    private <%- getType(attribute) %> $<%- strict ? toCamelCase(attribute.key) : attribute.key %>;
 <% } -%>
 
-  public function __construct(
+    public function __construct(
 <% for (const attribute of collection.attributes ){ -%>
 <% if (attribute.required) { -%>
-    <%- getType(attribute).replace('|null', '') %> $<%- strict ? toCamelCase(attribute.key) : attribute.key %><% if (collection.attributes.indexOf(attribute) < collection.attributes.length - 1) { %>,<% } %>
+        <%- getType(attribute).replace('|null', '') %> $<%- strict ? toCamelCase(attribute.key) : attribute.key %><% if (collection.attributes.indexOf(attribute) < collection.attributes.length - 1) { %>,<% } %>
 <% } else { -%>
-    ?<%- getType(attribute).replace('|null', '') %> $<%- strict ? toCamelCase(attribute.key) : attribute.key %> = null<% if (collection.attributes.indexOf(attribute) < collection.attributes.length - 1) { %>,<% } %>
+        ?<%- getType(attribute).replace('|null', '') %> $<%- strict ? toCamelCase(attribute.key) : attribute.key %> = null<% if (collection.attributes.indexOf(attribute) < collection.attributes.length - 1) { %>,<% } %>
 <% } -%>
 <% } -%>
-  ) {
+    ) {
 <% for (const attribute of collection.attributes ){ -%>
-    $this-><%- strict ? toCamelCase(attribute.key) : attribute.key %> = $<%- strict ? toCamelCase(attribute.key) : attribute.key %>;
+        $this-><%- strict ? toCamelCase(attribute.key) : attribute.key %> = $<%- strict ? toCamelCase(attribute.key) : attribute.key %>;
 <% } -%>
-  }
+    }
 
 <% for (const [index, attribute] of Object.entries(collection.attributes)) { -%>
-  public function get<%- toPascalCase(attribute.key) %>(): <%- getType(attribute) %> {
-    return $this-><%- strict ? toCamelCase(attribute.key) : attribute.key %>;
-  }
+    public function get<%- toPascalCase(attribute.key) %>(): <%- getType(attribute) %> {
+        return $this-><%- strict ? toCamelCase(attribute.key) : attribute.key %>;
+    }
 
-  public function set<%- toPascalCase(attribute.key) %>(<%- getType(attribute) %> $<%- strict ? toCamelCase(attribute.key) : attribute.key %>): void {
-    $this-><%- strict ? toCamelCase(attribute.key) : attribute.key %> = $<%- strict ? toCamelCase(attribute.key) : attribute.key %>;
-  }
+    public function set<%- toPascalCase(attribute.key) %>(<%- getType(attribute) %> $<%- strict ? toCamelCase(attribute.key) : attribute.key %>): void {
+        $this-><%- strict ? toCamelCase(attribute.key) : attribute.key %> = $<%- strict ? toCamelCase(attribute.key) : attribute.key %>;
+    }
 <% if (index < collection.attributes.length - 1) { %>
 <% } -%>
 <% } -%>

--- a/lib/type-generation/languages/swift.js
+++ b/lib/type-generation/languages/swift.js
@@ -55,7 +55,7 @@ class Swift extends LanguageMeta {
 <% if (attribute.format === 'enum') { -%>
 public enum <%- toPascalCase(attribute.key) %>: String, Codable, CaseIterable {
 <% for (const [index, element] of Object.entries(attribute.elements)) { -%>
-  case <%- strict ? toCamelCase(element) : element %> = "<%- element %>"
+    case <%- strict ? toCamelCase(element) : element %> = "<%- element %>"
 <% } -%>
 }
 
@@ -63,101 +63,101 @@ public enum <%- toPascalCase(attribute.key) %>: String, Codable, CaseIterable {
 <% } -%>
 public class <%- toPascalCase(collection.name) %>: Codable {
 <% for (const attribute of collection.attributes) { -%>
-  public let <%- strict ? toCamelCase(attribute.key) : attribute.key %>: <%- getType(attribute) %>
+    public let <%- strict ? toCamelCase(attribute.key) : attribute.key %>: <%- getType(attribute) %>
 <% } %>
-  enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
 <% for (const attribute of collection.attributes) { -%>
-    case <%- strict ? toCamelCase(attribute.key) : attribute.key %> = "<%- attribute.key %>"
+        case <%- strict ? toCamelCase(attribute.key) : attribute.key %> = "<%- attribute.key %>"
 <% } -%>
-  }
+    }
 
-  init(
+    public init(
 <% for (const [index, attribute] of Object.entries(collection.attributes)) { -%>
-    <%- strict ? toCamelCase(attribute.key) : attribute.key %>: <%- getType(attribute) %><% if (index < collection.attributes.length - 1) { %>,<% } %>
+        <%- strict ? toCamelCase(attribute.key) : attribute.key %>: <%- getType(attribute) %><% if (index < collection.attributes.length - 1) { %>,<% } %>
 <% } -%>
-  ) {
+    ) {
 <% for (const attribute of collection.attributes) { -%>
-    self.<%- strict ? toCamelCase(attribute.key) : attribute.key %> = <%- strict ? toCamelCase(attribute.key) : attribute.key %>
+        self.<%- strict ? toCamelCase(attribute.key) : attribute.key %> = <%- strict ? toCamelCase(attribute.key) : attribute.key %>
 <% } -%>
-  }
+    }
 
-  public required init(from decoder: Decoder) throws {
-    let container = try decoder.container(keyedBy: CodingKeys.self)
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
 
 <% for (const attribute of collection.attributes) { -%>
-<% if (attribute.required) { -%>
-    self.<%- strict ? toCamelCase(attribute.key) : attribute.key %> = try container.decode(<%- getType(attribute).replace('?', '') %>.self, forKey: .<%- strict ? toCamelCase(attribute.key) : attribute.key %>)
+<% if (!(!attribute.required && attribute.default === null)) { -%>
+        self.<%- strict ? toCamelCase(attribute.key) : attribute.key %> = try container.decode(<%- getType(attribute).replace('?', '') %>.self, forKey: .<%- strict ? toCamelCase(attribute.key) : attribute.key %>)
 <% } else { -%>
-    self.<%- strict ? toCamelCase(attribute.key) : attribute.key %> = try container.decodeIfPresent(<%- getType(attribute).replace('?', '') %>.self, forKey: .<%- strict ? toCamelCase(attribute.key) : attribute.key %>)
+        self.<%- strict ? toCamelCase(attribute.key) : attribute.key %> = try container.decodeIfPresent(<%- getType(attribute).replace('?', '') %>.self, forKey: .<%- strict ? toCamelCase(attribute.key) : attribute.key %>)
 <% } -%>
 <% } -%>
-  }
+    }
 
-  public func encode(to encoder: Encoder) throws {
-    var container = encoder.container(keyedBy: CodingKeys.self)
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
 
 <% for (const attribute of collection.attributes) { -%>
-<% if (attribute.required) { -%>
-    try container.encode(<%- strict ? toCamelCase(attribute.key) : attribute.key %>, forKey: .<%- strict ? toCamelCase(attribute.key) : attribute.key %>)
+<% if (!(!attribute.required && attribute.default === null)) { -%>
+        try container.encode(<%- strict ? toCamelCase(attribute.key) : attribute.key %>, forKey: .<%- strict ? toCamelCase(attribute.key) : attribute.key %>)
 <% } else { -%>
-    try container.encodeIfPresent(<%- strict ? toCamelCase(attribute.key) : attribute.key %>, forKey: .<%- strict ? toCamelCase(attribute.key) : attribute.key %>)
+        try container.encodeIfPresent(<%- strict ? toCamelCase(attribute.key) : attribute.key %>, forKey: .<%- strict ? toCamelCase(attribute.key) : attribute.key %>)
 <% } -%>
 <% } -%>
-  }
+    }
 
-  public func toMap() -> [String: Any] {
-    return [
+    public func toMap() -> [String: Any] {
+        return [
 <% for (const [index, attribute] of Object.entries(collection.attributes)) { -%>
 <% if (attribute.type === 'relationship') { -%>
-      "<%- attribute.key %>": <%- strict ? toCamelCase(attribute.key) : attribute.key %> as Any<% if (index < collection.attributes.length - 1) { %>,<% } %>
+            "<%- attribute.key %>": <%- strict ? toCamelCase(attribute.key) : attribute.key %> as Any<% if (index < collection.attributes.length - 1) { %>,<% } %>
 <% } else if (attribute.array && attribute.type !== 'string' && attribute.type !== 'integer' && attribute.type !== 'float' && attribute.type !== 'boolean') { -%>
-      "<%- attribute.key %>": <%- strict ? toCamelCase(attribute.key) : attribute.key %>?.map { $0.toMap() } as Any<% if (index < collection.attributes.length - 1) { %>,<% } %>
+            "<%- attribute.key %>": <%- strict ? toCamelCase(attribute.key) : attribute.key %>?.map { $0.toMap() } as Any<% if (index < collection.attributes.length - 1) { %>,<% } %>
 <% } else { -%>
-      "<%- attribute.key %>": <%- strict ? toCamelCase(attribute.key) : attribute.key %> as Any<% if (index < collection.attributes.length - 1) { %>,<% } %>
+            "<%- attribute.key %>": <%- strict ? toCamelCase(attribute.key) : attribute.key %> as Any<% if (index < collection.attributes.length - 1) { %>,<% } %>
 <% } -%>
 <% } -%>
-    ]
-  }
+        ]
+    }
 
-  public static func from(map: [String: Any]) -> <%- toPascalCase(collection.name) %> {
-    return <%- toPascalCase(collection.name) %>(
+    public static func from(map: [String: Any]) -> <%- toPascalCase(collection.name) %> {
+        return <%- toPascalCase(collection.name) %>(
 <% for (const [index, attribute] of Object.entries(collection.attributes)) { -%>
 <% if (attribute.type === 'relationship') { -%>
 <% if ((attribute.relationType === 'oneToMany' && attribute.side === 'parent') || (attribute.relationType === 'manyToOne' && attribute.side === 'child') || attribute.relationType === 'manyToMany') { -%>
-      <%- strict ? toCamelCase(attribute.key) : attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> [<%- toPascalCase(attribute.relatedCollection) %>]<% if (index < collection.attributes.length - 1) { %>,<% } %>
+            <%- strict ? toCamelCase(attribute.key) : attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> [<%- toPascalCase(attribute.relatedCollection) %>]<% if (index < collection.attributes.length - 1) { %>,<% } %>
 <% } else { -%>
-      <%- strict ? toCamelCase(attribute.key) : attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> <%- toPascalCase(attribute.relatedCollection) %><% if (index < collection.attributes.length - 1) { %>,<% } %>
+            <%- strict ? toCamelCase(attribute.key) : attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> <%- toPascalCase(attribute.relatedCollection) %><% if (index < collection.attributes.length - 1) { %>,<% } %>
 <% } -%>
 <% } else if (attribute.array) { -%>
 <% if (attribute.type === 'string') { -%>
-      <%- strict ? toCamelCase(attribute.key) : attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> [String]<% if (index < collection.attributes.length - 1) { %>,<% } %>
+            <%- strict ? toCamelCase(attribute.key) : attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> [String]<% if (index < collection.attributes.length - 1) { %>,<% } %>
 <% } else if (attribute.type === 'integer') { -%>
-      <%- strict ? toCamelCase(attribute.key) : attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> [Int]<% if (index < collection.attributes.length - 1) { %>,<% } %>
+            <%- strict ? toCamelCase(attribute.key) : attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> [Int]<% if (index < collection.attributes.length - 1) { %>,<% } %>
 <% } else if (attribute.type === 'float') { -%>
-      <%- strict ? toCamelCase(attribute.key) : attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> [Double]<% if (index < collection.attributes.length - 1) { %>,<% } %>
+            <%- strict ? toCamelCase(attribute.key) : attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> [Double]<% if (index < collection.attributes.length - 1) { %>,<% } %>
 <% } else if (attribute.type === 'boolean') { -%>
-      <%- strict ? toCamelCase(attribute.key) : attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> [Bool]<% if (index < collection.attributes.length - 1) { %>,<% } %>
+            <%- strict ? toCamelCase(attribute.key) : attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> [Bool]<% if (index < collection.attributes.length - 1) { %>,<% } %>
 <% } else { -%>
-      <%- strict ? toCamelCase(attribute.key) : attribute.key %>: (map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> [[String: Any]])<% if (!attribute.required) { %>?<% } %>.map { <%- toPascalCase(attribute.type) %>.from(map: $0) }<% if (index < collection.attributes.length - 1) { %>,<% } %>
+            <%- strict ? toCamelCase(attribute.key) : attribute.key %>: (map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> [[String: Any]])<% if (!attribute.required) { %>?<% } %>.map { <%- toPascalCase(attribute.type) %>.from(map: $0) }<% if (index < collection.attributes.length - 1) { %>,<% } %>
 <% } -%>
 <% } else { -%>
 <% if ((attribute.type === 'string' || attribute.type === 'email' || attribute.type === 'datetime') && attribute.format !== 'enum') { -%>
-      <%- strict ? toCamelCase(attribute.key) : attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> String<% if (index < collection.attributes.length - 1) { %>,<% } %>
+            <%- strict ? toCamelCase(attribute.key) : attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> String<% if (index < collection.attributes.length - 1) { %>,<% } %>
 <% } else if (attribute.type === 'string' && attribute.format === 'enum') { -%>
-      <%- strict ? toCamelCase(attribute.key) : attribute.key %>: <%- toPascalCase(attribute.key) %>(rawValue: map["<%- attribute.key %>"] as! String)!<% if (index < collection.attributes.length - 1) { %>,<% } %>
+            <%- strict ? toCamelCase(attribute.key) : attribute.key %>: <%- toPascalCase(attribute.key) %>(rawValue: map["<%- attribute.key %>"] as! String)!<% if (index < collection.attributes.length - 1) { %>,<% } %>
 <% } else if (attribute.type === 'integer') { -%>
-      <%- strict ? toCamelCase(attribute.key) : attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> Int<% if (index < collection.attributes.length - 1) { %>,<% } %>
+            <%- strict ? toCamelCase(attribute.key) : attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> Int<% if (index < collection.attributes.length - 1) { %>,<% } %>
 <% } else if (attribute.type === 'float') { -%>
-      <%- strict ? toCamelCase(attribute.key) : attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> Double<% if (index < collection.attributes.length - 1) { %>,<% } %>
+            <%- strict ? toCamelCase(attribute.key) : attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> Double<% if (index < collection.attributes.length - 1) { %>,<% } %>
 <% } else if (attribute.type === 'boolean') { -%>
-      <%- strict ? toCamelCase(attribute.key) : attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> Bool<% if (index < collection.attributes.length - 1) { %>,<% } %>
+            <%- strict ? toCamelCase(attribute.key) : attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> Bool<% if (index < collection.attributes.length - 1) { %>,<% } %>
 <% } else { -%>
-      <%- strict ? toCamelCase(attribute.key) : attribute.key %>: <%- toPascalCase(attribute.type) %>.from(map: map["<%- attribute.key %>"] as! [String: Any])<% if (index < collection.attributes.length - 1) { %>,<% } %>
+            <%- strict ? toCamelCase(attribute.key) : attribute.key %>: <%- toPascalCase(attribute.type) %>.from(map: map["<%- attribute.key %>"] as! [String: Any])<% if (index < collection.attributes.length - 1) { %>,<% } %>
 <% } -%>
 <% } -%>
 <% } -%>
-    )
-  }
+        )
+    }
 }`;
   }
 

--- a/lib/type-generation/languages/typescript.js
+++ b/lib/type-generation/languages/typescript.js
@@ -80,21 +80,21 @@ class TypeScript extends LanguageMeta {
 export enum <%- toPascalCase(attribute.key) %> {
 <% const entries = Object.entries(attribute.elements); -%>
 <% for (let i = 0; i < entries.length; i++) { -%>
-  <%- toUpperSnakeCase(entries[i][1]) %> = "<%- entries[i][1] %>"<% if (i !== entries.length - 1) { %>,<% } %>
+    <%- toUpperSnakeCase(entries[i][1]) %> = "<%- entries[i][1] %>"<% if (i !== entries.length - 1) { %>,<% } %>
 <% } -%>
 }
 
 <% } -%>
 <% } -%>
 <% } -%>
-<% for (const collection of collections) { -%>
+<% for (const [index, collection] of Object.entries(collections)) { -%>
 export type <%- toPascalCase(collection.name) %> = Models.Document & {
 <% for (const attribute of collection.attributes) { -%>
-  <%- strict ? toCamelCase(attribute.key) : attribute.key %>: <%- getType(attribute) %>;
+    <%- strict ? toCamelCase(attribute.key) : attribute.key %>: <%- getType(attribute) %>;
 <% } -%>
-}
-
-<% } %>`;
+}<% if (index < collections.length - 1) { %>
+<% } %>
+<% } -%>`;
   }
 
   getFileName(_) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "appwrite-cli",
   "homepage": "https://appwrite.io/support",
   "description": "Appwrite is an open-source self-hosted backend server that abstract and simplify complex and repetitive development tasks behind a very simple REST API",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "license": "BSD-3-Clause",
   "main": "index.js",
   "bin": {

--- a/scoop/appwrite.json
+++ b/scoop/appwrite.json
@@ -1,12 +1,12 @@
 {
 	"$schema": "https://raw.githubusercontent.com/ScoopInstaller/Scoop/master/schema.json",
-	"version": "8.2.1",
+	"version": "8.2.2",
 	"description": "The Appwrite CLI is a command-line application that allows you to interact with Appwrite and perform server-side tasks using your terminal.",
 	"homepage": "https://github.com/appwrite/sdk-for-cli",
 	"license": "BSD-3-Clause",
 	"architecture": {
 		"64bit": {
-			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/8.2.1/appwrite-cli-win-x64.exe",
+			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/8.2.2/appwrite-cli-win-x64.exe",
 			"bin": [
 				[
 					"appwrite-cli-win-x64.exe",
@@ -15,7 +15,7 @@
 			]
 		},
 		"arm64": {
-			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/8.2.1/appwrite-cli-win-arm64.exe",
+			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/8.2.2/appwrite-cli-win-arm64.exe",
 			"bin": [
 				[
 					"appwrite-cli-win-arm64.exe",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

* Fix object comparison logic when pushing settings
* Type generation fixes:
   * Dart: Fixed import casing to snake_case, removed `extends Document` and hardcoded attributes, removed unnecessary imports
   * Java: Fixed indentation to 4 spaces, updated imports to `java.util.Objects`, fixed enum casing in strict mode as per [Oracle official docs](https://docs.oracle.com/javase/tutorial/java/javaOO/enum.html)
   * Javascript: Updated optional values formatting from `|null` to `| null`
   * Kotlin: Fixed indentation to 4 spaces per [Kotlinlang official docs](https://kotlinlang.org/docs/coding-conventions.html#indentation)
   * PHP: Fixed indentation to 4 spaces per [PHP Fig official docs](https://www.php-fig.org/psr/psr-2/)
   * Swift: Fixed indentation to 4 spaces, improved `decodeIfPresent` usage for optionals, added missing `public` to `init` method
   * Typescript: Fixed indentation to 4 spaces per [Typescript coding guidelines](https://github.com/microsoft/TypeScript/wiki/Coding-guidelines)

## Test Plan

## Related PRs and Issues

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes.