### PR TITLE
Updated typescript template generator to use Models.DocumentBase

### DIFF
--- a/lib/type-generation/languages/typescript.js
+++ b/lib/type-generation/languages/typescript.js
@@ -88,7 +88,7 @@ export enum <%- toPascalCase(attribute.key) %> {
 <% } -%>
 <% } -%>
 <% for (const [index, collection] of Object.entries(collections)) { -%>
-export type <%- toPascalCase(collection.name) %> = Models.Document & {
+export type <%- toPascalCase(collection.name) %> = Models.DocumentBase & {
 <% for (const attribute of collection.attributes) { -%>
     <%- strict ? toCamelCase(attribute.key) : attribute.key %>: <%- getType(attribute) %>;
 <% } -%>


### PR DESCRIPTION
## What does this PR do?

The [https://appwrite.io/docs/products/databases/type-generation](appwrite-cli type generation) for TypeScript defined a Document type as:

```ts
import { Models } from 'appwrite';

export type Books = Models.Document & {
  name: string;
  author: string;
  releaseYear: string | null;
  ...
}
```

However, by extending `Models.Document`, the `[key: string]: any` property makes attributes that don't exist still allowed.

To solve this, PR [!10171 in the appwrite repository](https://github.com/appwrite/appwrite/pull/10171) adds the `DocumentBase` type that defines the default attributes of a Document.

The type-generator can then use this type to define the specific types for the collections.

## Test Plan

Did not write any tests (yet); Let me know if you think this is needed.

## Related PRs and Issues

- PR [!10171](https://github.com/appwrite/appwrite/pull/10171) in appwrite.
- PR .... in the docs

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes