### PR TITLE
fix: handle null values in drawTable to prevent Node 22 crash

### DIFF
--- a/repro_bug_sk.js
+++ b/repro_bug_sk.js
@@ -1,0 +1,32 @@
+// repro_bug.js
+
+import { drawTable } from './lib/parser.ts'; // Change .js to .ts
+
+
+console.log("--- Test 1: Simulating Database Trigger with Null values ---");
+const mockExecutionData = [
+    {
+        $id: "65ae12345",
+        status: "completed",
+        duration: 0.123,
+        scheduledAt: null, // This is the value that triggers the crash
+        trigger: "database"
+    }
+];
+
+try {
+    // Before your fix, this line would throw:
+    // TypeError: Cannot convert undefined or null to object
+    drawTable(mockExecutionData);
+    console.log("\n✅ Test 1 Passed: Table rendered successfully despite null values.");
+} catch (error) {
+    console.error("\nTest 1 Failed:", error.message);
+}
+
+console.log("\n--- Test 2: Simulating Empty Object array ---");
+try {
+    drawTable([null]);
+    console.log("✅ Test 2 Passed: Handled [null] array gracefully.");
+} catch (error) {
+    console.error(" Test 2 Failed:", error.message);
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

In Node 22, the CLI crashes with `TypeError: Cannot convert undefined or null to object` when a function execution log contains `null` for metadata fields like `scheduledAt`. This occurs because `typeof null` returns `'object'`, leading the parser to attempt table rendering on non-iterable values.

The Solution
- Added a guard clause at the start of `drawTable` to handle `null` or empty data arrays.
- Implemented null-safe spreading `(item || {})` within `reduce` and `map` to prevent illegal object conversions.
- Updated the row value loop to explicitly handle `null` placeholders with a hyphen (`-`).
-
## Test Plan
Test Plan
I verified these changes by creating a reproduction script that simulates the exact conditions under which the TypeError occurs in Node 22 (specifically when a function execution log contains null metadata from a database-triggered event).

Verification Steps:

Environment: Node v22.15.0.

Reproduction Script: Created a script that passes a mock execution object with scheduledAt: null into the drawTable function.

Command Execution: Ran the test using npx tsx repro_bug_sk.js.

Test Results:

Test 1 (Null Metadata): Passed. The table rendered correctly, displaying a hyphen - for the null scheduledAt field instead of crashing with a TypeError.

Test 2 (Null Array Element): Passed. The parser gracefully handled an array containing a null element [null] without attempting to access keys.
(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)
Output:
--- Test 1: Simulating Database Trigger with Null values ---

  $id       │ status    │ duration │ scheduledAt │ trigger
 ───────────┼───────────┼──────────┼─────────────┼──────────
  65ae12345 │ completed │ 0.123    │ -           │ database

✅ Test 1 Passed: Table rendered successfully despite null values.

--- Test 2: Simulating Empty Object array ---
[]
✅ Test 2 Passed: Handled [null] array gracefully.


## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness when processing data with null or undefined values in tables
  * Fixed edge cases that could cause crashes when handling missing fields or empty datasets
  * Enhanced empty state handling for safer data processing

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->