### PR TITLE
fix: Add entrypoint environment variable to Docker params

### DIFF
--- a/lib/emulation/docker.ts
+++ b/lib/emulation/docker.ts
@@ -218,6 +218,7 @@ export async function dockerStart(
   params.push("-p", `${port}:3000`);
   params.push("-e", "OPEN_RUNTIMES_ENV=development");
   params.push("-e", "OPEN_RUNTIMES_SECRET=");
+  params.push("-e", `OPEN_RUNTIMES_ENTRYPOINT=${func.entrypoint}`);
 
   for (const k of Object.keys(variables)) {
     params.push("-e", `${k}=${variables[k]}`);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
Supplement the missing entrypoint environment variables when starting docker, otherwise the JAVA runtimes container will not find the entry object upon startup.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker container runtime environment configuration to pass function entrypoint information during execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->