### PR TITLE
Add build validation workflow for Node and platform binaries

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -52,11 +52,10 @@ jobs:
         with:
           bun-version: "latest"
 
-      - name: Setup binfmt and QEMU
-        run: |
-          sudo apt update
-          sudo apt install -y qemu binfmt-support qemu-user-static
-          update-binfmts --display
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: amd64,arm64
 
       - name: Setup ldid
         run: |


### PR DESCRIPTION
## Summary
- add a new GitHub Actions workflow: `Build Validation`
- validate Node-based CLI packaging (`node index.js -v` and `npm pack`)
- validate all platform binary builds using Bun (`linux-x64`, `linux-arm64`, `windows-x64`, `windows-arm64`, `mac-x64`, `mac-arm64`)
- verify all expected build artifacts are generated and non-empty

## Workflow behavior
- triggers on `pull_request`
- enables concurrency with in-progress cancellation for the same ref
- includes required setup for cross-platform packaging (`qemu/binfmt` and `ldid`)
