### PR TITLE
fix: update CLI runtime version from v4 to v5

### DIFF
--- a/lib/emulation/utils.ts
+++ b/lib/emulation/utils.ts
@@ -4,7 +4,7 @@ import { log } from "../parser.js";
 import { sdkForConsole, sdkForProject } from "../sdks.js";
 import { Projects, Scopes, Users } from "@appwrite.io/console";
 
-export const openRuntimesVersion = "v4";
+export const openRuntimesVersion = "v5";
 
 export const runtimeNames: Record<string, string> = {
   node: "Node.js",


### PR DESCRIPTION
## What does this PR do?

This PR updates the CLI runtime version from **v4 to v5** in the emulation utilities.

The CLI was using `openRuntimesVersion = "v4"`, while the backend and Docker configuration use **v5**, leading to a version mismatch and runtime execution issues.

This change aligns the CLI runtime version with the backend to ensure consistent and correct runtime execution.

---

## Test Plan

* Cloned the repository locally.
* Updated `openRuntimesVersion` from `v4` to `v5` in `lib/emulation/utils.ts`.
* Verified that only the intended line was modified.
* Confirmed alignment with backend configuration (`v5` runtime in docker-compose).
* Ensured there are no syntax or build errors after the change.

---

## Related PRs and Issues

Fixes appwrite/appwrite#11846

---

### Have you read the Contributing Guidelines on issues?

Yes, I have read the contributing guidelines and followed them while creating this PR.
