### PR TITLE
Fix Homebrew checksum matcher in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -115,7 +115,7 @@ jobs:
           end
 
           checksums.each do |artifact, checksum|
-            pattern = /(\Q#{artifact}\E"\n\s+sha256 ")([0-9a-f]{64})(")/
+            pattern = /(#{Regexp.escape(artifact)}"\n\s+sha256 ")([0-9a-f]{64})(")/
             unless text.sub!(pattern) { "#{$1}#{checksum}#{$3}" }
               abort("Failed to update checksum for #{artifact}")
             end


### PR DESCRIPTION
## What does this PR do?

Fixes the Homebrew checksum replacement regex in the publish workflow.

The current workflow uses a Ruby regex literal with `\Q...\E` interpolation when rewriting `Formula/appwrite.rb`, and that matcher does not match the generated formula content during the release job. The first checksum replacement fails and aborts the publish step.

Failed run:
https://github.com/appwrite/sdk-for-cli/actions/runs/24404302600/job/71283184664

## Test Plan

- Reproduced the failure path locally against the current `Formula/appwrite.rb`
- Verified that replacing `\Q#{artifact}\E` with `#{Regexp.escape(artifact)}` allows all four checksum substitutions to succeed

## Related

- No linked issue
