### PR TITLE
chore: patch release 18.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 18.0.1
+
+* Fixed Homebrew checksum regex matcher in publish workflow
+
 ## 18.0.0
 
 * Breaking: Moved `keys` commands from `projects` to `project` service. They no longer require `--project-id`, but `create-key` now requires `--key-id`

--- a/Formula/appwrite.rb
+++ b/Formula/appwrite.rb
@@ -2,7 +2,7 @@ class Appwrite < Formula
   desc "Command-line tool for interacting with the Appwrite API"
   homepage "https://appwrite.io"
   license "BSD-3-Clause"
-  version "18.0.0"
+  version "18.0.1"
 
   def self.binary_arch
     Hardware::CPU.arm? ? "arm64" : "x64"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appwrite-cli",
-  "version": "18.0.0",
+  "version": "18.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "appwrite-cli",
-      "version": "18.0.0",
+      "version": "18.0.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@appwrite.io/console": "~9.1.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "homepage": "https://appwrite.io/support",
   "description": "Appwrite is an open-source self-hosted backend server that abstracts and simplifies complex and repetitive development tasks behind a very simple REST API",
-  "version": "18.0.0",
+  "version": "18.0.1",
   "license": "BSD-3-Clause",
   "main": "dist/index.cjs",
   "module": "dist/index.js",


### PR DESCRIPTION
## Summary

- Bumps version to `18.0.1` (`package.json`, `package-lock.json`, `Formula/appwrite.rb`)
- Adds changelog entry for the patch

The 18.0.0 publish workflow [failed](https://github.com/appwrite/sdk-for-cli/actions/runs/24404302600) at the "Update Homebrew formula checksums" step because it ran with the old `\Q...\E` regex syntax. The fix landed on master in #297 but the workflow used the YAML from the `18.0.0` tag.

This patch release will re-trigger the publish workflow with the corrected regex so Homebrew checksums get updated properly.

## Test plan

- [ ] Merge PR
- [ ] Create `18.0.1` GitHub release targeting `master`
- [ ] Verify publish workflow completes successfully including Homebrew formula update