### PR TITLE
feat: SDK update for version 20.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 20.1.0
+
+* Added `--switch` and `--new` flags on `appwrite login` to explicitly manage multiple saved accounts
+* Fixed `appwrite login` to verify the current session via the API and clean up stale guest/unauthorized sessions instead of trusting local metadata
+* Updated Cloud account login to normalize endpoints to `https://cloud.appwrite.io/v1` and reject regional Cloud endpoints
+
 ## 20.0.0
 
 * Breaking: Removed `projects delete`. Use `project delete` instead

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Once the installation is complete, you can verify the install using
 
 ```sh
 $ appwrite -v
-20.0.0
+20.1.0
 ```
 
 ### Install using prebuilt binaries
@@ -83,7 +83,7 @@ $ scoop install https://raw.githubusercontent.com/appwrite/sdk-for-cli/master/sc
 Once the installation completes, you can verify your install using
 ```
 $ appwrite -v
-20.0.0
+20.1.0
 ```
 
 ## Getting Started 

--- a/install.ps1
+++ b/install.ps1
@@ -13,8 +13,8 @@
 # You can use "View source" of this page to see the full script.
 
 # REPO
-$GITHUB_x64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/20.0.0/appwrite-cli-win-x64.exe"
-$GITHUB_arm64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/20.0.0/appwrite-cli-win-arm64.exe"
+$GITHUB_x64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/20.1.0/appwrite-cli-win-x64.exe"
+$GITHUB_arm64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/20.1.0/appwrite-cli-win-arm64.exe"
 
 $APPWRITE_BINARY_NAME = "appwrite.exe"
 

--- a/install.sh
+++ b/install.sh
@@ -120,7 +120,7 @@ verifyMacOSCodeSignature() {
 downloadBinary() {
     echo "[2/5] Downloading executable for $OS ($ARCH) ..."
 
-    GITHUB_LATEST_VERSION="20.0.0"
+    GITHUB_LATEST_VERSION="20.1.0"
     GITHUB_FILE="appwrite-cli-${OS}-${ARCH}"
     GITHUB_URL="https://github.com/$GITHUB_REPOSITORY_NAME/releases/download/$GITHUB_LATEST_VERSION/$GITHUB_FILE"
 

--- a/lib/commands/generic.ts
+++ b/lib/commands/generic.ts
@@ -2,7 +2,11 @@ import inquirer from "inquirer";
 import { Command } from "commander";
 import { Client } from "@appwrite.io/console";
 import { sdkForConsole } from "../sdks.js";
-import { globalConfig, localConfig } from "../config.js";
+import {
+  globalConfig,
+  localConfig,
+  normalizeCloudConsoleEndpoint,
+} from "../config.js";
 import { EXECUTABLE_NAME } from "../constants.js";
 import {
   actionRunner,
@@ -16,14 +20,20 @@ import {
   drawTable,
   cliConfig,
 } from "../parser.js";
+import { isCloudHostname } from "../utils.js";
 import ID from "../id.js";
 import {
   questionsLogin,
   questionsLogout,
   questionsListFactors,
   questionsMFAChallenge,
+  questionsSwitchAccount,
 } from "../questions.js";
-import { Account, Client as ConsoleClient } from "@appwrite.io/console";
+import {
+  Account,
+  Client as ConsoleClient,
+  type Models,
+} from "@appwrite.io/console";
 import ClientLegacy from "../client.js";
 
 const DEFAULT_ENDPOINT = "https://cloud.appwrite.io/v1";
@@ -36,6 +46,56 @@ interface AppwriteError {
 const isMfaRequiredError = (err: unknown): err is AppwriteError =>
   (err as AppwriteError)?.type === "user_more_factors_required" ||
   (err as AppwriteError)?.response === "user_more_factors_required";
+
+const isGuestUnauthorizedError = (err: unknown): err is AppwriteError =>
+  (err as AppwriteError)?.type === "general_unauthorized_scope" ||
+  (err as AppwriteError)?.response === "general_unauthorized_scope";
+
+const isRegionalCloudEndpoint = (endpoint: string): boolean => {
+  try {
+    const hostname = new URL(endpoint).hostname;
+    return isCloudHostname(hostname) && hostname !== "cloud.appwrite.io";
+  } catch (_error) {
+    return false;
+  }
+};
+
+const restoreCurrentSession = (sessionId: string): void => {
+  globalConfig.setCurrentSession(
+    globalConfig.getSessionIds().includes(sessionId) ? sessionId : "",
+  );
+};
+
+const removeCurrentSession = (): void => {
+  const current = globalConfig.getCurrentSession();
+  globalConfig.setCurrentSession("");
+  globalConfig.removeSession(current);
+};
+
+const getCurrentAccount = async (): Promise<Models.User | null> => {
+  if (globalConfig.getEndpoint() === "" || globalConfig.getCookie() === "") {
+    return null;
+  }
+
+  const endpoint = normalizeCloudConsoleEndpoint(globalConfig.getEndpoint());
+  if (endpoint !== globalConfig.getEndpoint()) {
+    globalConfig.setEndpoint(endpoint);
+  }
+
+  const client = await sdkForConsole(false);
+  const accountClient = new Account(client);
+
+  try {
+    const account = await accountClient.get();
+    globalConfig.setEmail(account.email);
+    return account;
+  } catch (err) {
+    if (isGuestUnauthorizedError(err)) {
+      removeCurrentSession();
+    }
+    return null;
+  }
+};
 
 const createLegacyConsoleClient = (endpoint: string): ClientLegacy => {
   const legacyClient = new ClientLegacy();
@@ -115,7 +175,9 @@ const getSessionAccountKey = (sessionId: string): string | undefined => {
     | { email?: string; endpoint?: string }
     | undefined;
   if (!session) return undefined;
-  return `${session.email ?? ""}|${session.endpoint ?? ""}`;
+  return `${session.email ?? ""}|${normalizeCloudConsoleEndpoint(
+    session.endpoint ?? "",
+  )}`;
 };
 
 /**
@@ -165,33 +227,62 @@ export const loginCommand = async ({
   endpoint,
   mfa,
   code,
+  switch: switchAccount,
+  new: newAccount,
 }: {
   email?: string;
   password?: string;
   endpoint?: string;
   mfa?: string;
   code?: string;
+  switch?: boolean;
+  new?: boolean;
 }): Promise<void> => {
-  const oldCurrent = globalConfig.getCurrentSession();
+  let oldCurrent = globalConfig.getCurrentSession();
 
-  const configEndpoint =
-    (endpoint ?? globalConfig.getEndpoint()) || DEFAULT_ENDPOINT;
+  if (switchAccount && newAccount) {
+    throw new Error("Use either --switch or --new, not both.");
+  }
+
+  if (endpoint && isRegionalCloudEndpoint(endpoint)) {
+    throw new Error(
+      `Cloud login uses ${DEFAULT_ENDPOINT}. Regional Cloud endpoints are for project API calls, not account login.`,
+    );
+  }
+
+  const configEndpoint = normalizeCloudConsoleEndpoint(
+    (endpoint ?? globalConfig.getEndpoint()) || DEFAULT_ENDPOINT,
+  );
 
   if (globalConfig.getCurrentSession() !== "") {
-    log("You are currently signed in as " + globalConfig.getEmail());
+    const account = await getCurrentAccount();
+    oldCurrent = globalConfig.getCurrentSession();
 
-    if (globalConfig.getSessions().length === 1) {
-      hint("You can sign in and manage multiple accounts with Appwrite CLI");
+    if (account) {
+      if (!email && !password && !endpoint && !switchAccount && !newAccount) {
+        success("Already logged in as " + account.email);
+        hint(`Use '${EXECUTABLE_NAME} login --new' to add another account`);
+        return;
+      }
     }
   }
 
-  const answers =
-    email && password
-      ? { email, password }
-      : await inquirer.prompt(questionsLogin);
+  let answers;
+  if (switchAccount) {
+    if (!globalConfig.getSessions().some((session) => session.email)) {
+      throw new Error(
+        `No signed-in accounts found. Run '${EXECUTABLE_NAME} login' to sign in.`,
+      );
+    }
+    answers = await inquirer.prompt(questionsSwitchAccount);
+  } else if (email && password) {
+    answers = { email, password };
+  } else {
+    answers = await inquirer.prompt(questionsLogin);
+  }
 
   if (!answers.method) {
-    answers.method = "login";
+    answers.method = switchAccount ? "select" : "login";
   }
 
   if (answers.method === "select") {
@@ -201,7 +292,21 @@ export const loginCommand = async ({
       throw Error("Session ID not found");
     }
 
+    if (accountId === oldCurrent) {
+      const account = await getCurrentAccount();
+      if (account) {
+        success(`Already using ${account.email}`);
+        return;
+      }
+      throw new Error(
+        `Selected account session is no longer valid. Run '${EXECUTABLE_NAME} login --switch' again.`,
+      );
+    }
+
     globalConfig.setCurrentSession(accountId);
+    globalConfig.setEndpoint(
+      normalizeCloudConsoleEndpoint(globalConfig.getEndpoint()),
+    );
 
     const client = await sdkForConsole(false);
     const accountClient = new Account(client);
@@ -213,6 +318,10 @@ export const loginCommand = async ({
       await accountClient.get();
     } catch (err) {
       if (!isMfaRequiredError(err)) {
+        if (isGuestUnauthorizedError(err)) {
+          globalConfig.removeSession(accountId);
+        }
+        restoreCurrentSession(oldCurrent);
         throw err;
       }
 
@@ -306,14 +415,8 @@ export const whoami = new Command("whoami")
         return;
       }
 
-      const client = await sdkForConsole(false);
-      const accountClient = new Account(client);
-
-      let account;
-
-      try {
-        account = await accountClient.get();
-      } catch (_) {
+      const account = await getCurrentAccount();
+      if (!account) {
         error("No user is signed in. To sign in, run 'appwrite login'");
         return;
       }
@@ -358,6 +461,8 @@ export const login = new Command("login")
     `Multi-factor authentication login factor: totp, email, phone or recoveryCode`,
   )
   .option(`--code [code]`, `Multi-factor code`)
+  .option(`--switch`, `Switch to another signed-in account`)
+  .option(`--new`, `Sign in to another account`)
   .configureHelp({
     helpWidth: process.stdout.columns || 80,
   })

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -103,6 +103,22 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
+export function normalizeCloudConsoleEndpoint(endpoint: string): string {
+  try {
+    const url = new URL(endpoint);
+    if (
+      url.hostname === "cloud.appwrite.io" ||
+      url.hostname.endsWith(".cloud.appwrite.io")
+    ) {
+      return "https://cloud.appwrite.io/v1";
+    }
+  } catch (_error) {
+    return endpoint;
+  }
+
+  return endpoint;
+}
+
 function ensureDirectoryForFile(filePath: string): void {
   const dir = _path.dirname(filePath);
   if (!fs.existsSync(dir)) {
@@ -1201,10 +1217,17 @@ class Global extends Config<GlobalConfigData> {
     sessions.forEach((sessionId) => {
       const sessionData = (this.data as any)[sessionId];
       const email = sessionData[Global.PREFERENCE_EMAIL] ?? "";
-      const endpoint = sessionData[Global.PREFERENCE_ENDPOINT] ?? "";
+      const endpoint = normalizeCloudConsoleEndpoint(
+        sessionData[Global.PREFERENCE_ENDPOINT] ?? "",
+      );
       const key = `${email}|${endpoint}`;
+      const existingSession = sessionMap.get(key);
 
-      if (sessionId === current || !sessionMap.has(key)) {
+      if (
+        !existingSession ||
+        sessionId === current ||
+        existingSession.id !== current
+      ) {
         sessionMap.set(key, {
           id: sessionId,
           endpoint,

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,7 +1,7 @@
 // SDK
 export const SDK_TITLE = 'Appwrite';
 export const SDK_TITLE_LOWER = 'appwrite';
-export const SDK_VERSION = '20.0.0';
+export const SDK_VERSION = '20.1.0';
 export const SDK_NAME = 'Command Line';
 export const SDK_PLATFORM = 'console';
 export const SDK_LANGUAGE = 'cli';

--- a/lib/questions.ts
+++ b/lib/questions.ts
@@ -823,16 +823,6 @@ export const questionsPullCollection: Question[] = [
 
 export const questionsLogin: Question[] = [
   {
-    type: "list",
-    name: "method",
-    message: "What would you like to do?",
-    choices: [
-      { name: "Login to an account", value: "login" },
-      { name: "Switch to an account", value: "select" },
-    ],
-    when: () => globalConfig.getSessions().length >= 2,
-  },
-  {
     type: "input",
     name: "email",
     message: "Enter your email",
@@ -842,7 +832,6 @@ export const questionsLogin: Question[] = [
       }
       return true;
     },
-    when: (answers: Answers) => answers.method !== "select",
   },
   {
     type: "password",
@@ -855,38 +844,36 @@ export const questionsLogin: Question[] = [
       }
       return true;
     },
-    when: (answers: Answers) => answers.method !== "select",
   },
+];
+
+export const questionsSwitchAccount: Question[] = [
   {
     type: "list",
     name: "accountId",
-    message: "Select an account to use",
+    message: "Select account:",
     choices() {
       const sessions = globalConfig.getSessions();
       const current = globalConfig.getCurrentSession();
 
       const data: Choice[] = [];
 
-      const longestEmail = sessions.reduce((prev: any, current: any) =>
-        prev && (prev.email ?? "").length > (current.email ?? "").length
-          ? prev
-          : current,
-      ).email.length;
-
       sessions.forEach((session: any) => {
         if (session.email) {
           data.push({
             current: current === session.id,
             value: session.id,
-            short: `${session.email} (${session.endpoint})`,
-            name: `${session.email.padEnd(longestEmail)} ${current === session.id ? chalk.green.bold("current") : " ".repeat(6)} ${session.endpoint}`,
+            short: session.email,
+            name:
+              session.endpoint === DEFAULT_ENDPOINT
+                ? session.email
+                : `${session.email} (${session.endpoint})`,
           });
         }
       });
 
       return data.sort((a, b) => Number(b.current) - Number(a.current));
     },
-    when: (answers: Answers) => answers.method === "select",
   },
 ];
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -317,7 +317,7 @@ const getHomebrewLatestVersion = async (
   }
 };
 
-const isCloudHostname = (hostname: string): boolean =>
+export const isCloudHostname = (hostname: string): boolean =>
   hostname === "cloud.appwrite.io" || hostname.endsWith(".cloud.appwrite.io");
 
 export const getConsoleBaseUrl = (endpoint: string): string => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appwrite-cli",
-  "version": "20.0.0",
+  "version": "20.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "appwrite-cli",
-      "version": "20.0.0",
+      "version": "20.1.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@appwrite.io/console": "12.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "homepage": "https://appwrite.io/support",
   "description": "Appwrite is an open-source self-hosted backend server that abstracts and simplifies complex and repetitive development tasks behind a very simple REST API",
-  "version": "20.0.0",
+  "version": "20.1.0",
   "license": "BSD-3-Clause",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/scoop/appwrite.config.json
+++ b/scoop/appwrite.config.json
@@ -1,12 +1,12 @@
 {
 	"$schema": "https://raw.githubusercontent.com/ScoopInstaller/Scoop/master/schema.json",
-	"version": "20.0.0",
+	"version": "20.1.0",
 	"description": "The Appwrite CLI is a command-line application that allows you to interact with Appwrite and perform server-side tasks using your terminal.",
 	"homepage": "https://github.com/appwrite/sdk-for-cli",
 	"license": "BSD-3-Clause",
 	"architecture": {
 		"64bit": {
-			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/20.0.0/appwrite-cli-win-x64.exe",
+			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/20.1.0/appwrite-cli-win-x64.exe",
 			"bin": [
 				[
 					"appwrite-cli-win-x64.exe",
@@ -15,7 +15,7 @@
 			]
 		},
 		"arm64": {
-			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/20.0.0/appwrite-cli-win-arm64.exe",
+			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/20.1.0/appwrite-cli-win-arm64.exe",
 			"bin": [
 				[
 					"appwrite-cli-win-arm64.exe",


### PR DESCRIPTION
This PR contains updates to the SDK for version 20.1.0.

## What's Changed

* Added `--switch` and `--new` flags on `appwrite login` to explicitly manage multiple saved accounts
* Fixed `appwrite login` to verify the current session via the API and clean up stale guest/unauthorized sessions instead of trusting local metadata
* Updated Cloud account login to normalize endpoints to `https://cloud.appwrite.io/v1` and reject regional Cloud endpoints