### PR TITLE
feat: Command Line SDK update for version 21.0.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,7 @@ on:
     types: [published]
 
 permissions:
+  actions: read
   id-token: write
   contents: write
 
@@ -18,6 +19,9 @@ jobs:
       # upstream fix (oven-sh/bun#29122).
       CLI_BUN_VERSION: '1.3.11'
       HOMEBREW_TAP_REPO: appwrite/homebrew-appwrite
+      WINDOWS_SIGNING_PROJECT_SLUG: ${{ vars.WINDOWS_SIGNING_PROJECT_SLUG || 'sdk-for-cli' }}
+      WINDOWS_SIGNING_POLICY_SLUG: ${{ vars.WINDOWS_SIGNING_POLICY_SLUG || 'release-signing' }}
+      WINDOWS_SIGNING_ARTIFACT_CONFIGURATION_SLUG: ${{ vars.WINDOWS_SIGNING_ARTIFACT_CONFIGURATION_SLUG || 'initial' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -29,7 +33,7 @@ jobs:
       - name: Setup binfmt with QEMU
         run: | 
           sudo apt update
-          sudo apt install qemu-system binfmt-support qemu-user-static
+          sudo apt install qemu-system binfmt-support qemu-user-static osslsigncode
           update-binfmts --display
 
       - name: Setup ldid
@@ -48,6 +52,65 @@ jobs:
           bun run mac-arm64
           bun run windows-x64
           bun run windows-arm64
+
+      - name: Upload unsigned Windows binaries
+        id: upload-windows-unsigned
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-unsigned
+          path: |
+            build/appwrite-cli-win-x64.exe
+            build/appwrite-cli-win-arm64.exe
+
+      - name: Submit Windows binaries for signing
+        uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2
+        with:
+          api-token: ${{ secrets.WINDOWS_SIGNING_API_TOKEN }}
+          organization-id: ${{ vars.WINDOWS_SIGNING_ORGANIZATION_ID }}
+          project-slug: ${{ env.WINDOWS_SIGNING_PROJECT_SLUG }}
+          signing-policy-slug: ${{ env.WINDOWS_SIGNING_POLICY_SLUG }}
+          artifact-configuration-slug: ${{ env.WINDOWS_SIGNING_ARTIFACT_CONFIGURATION_SLUG }}
+          github-artifact-id: ${{ steps.upload-windows-unsigned.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: build-signed
+          parameters: |
+            version: ${{ github.event.release.tag_name }}
+
+      - name: Replace unsigned Windows binaries
+        run: |
+          set -euo pipefail
+
+          signed_x64="$(find build-signed -type f -name 'appwrite-cli-win-x64.exe' -print -quit)"
+          signed_arm64="$(find build-signed -type f -name 'appwrite-cli-win-arm64.exe' -print -quit)"
+
+          if [ -z "$signed_x64" ] || [ -z "$signed_arm64" ]; then
+            echo "Signed Windows binaries were not found in build-signed"
+            find build-signed -type f -print
+            exit 1
+          fi
+
+          cp "$signed_x64" build/appwrite-cli-win-x64.exe
+          cp "$signed_arm64" build/appwrite-cli-win-arm64.exe
+
+      - name: Verify Windows signatures
+        run: |
+          set -euo pipefail
+
+          verify_signature() {
+            local file="$1"
+            local output
+
+            output="$(osslsigncode verify -in "$file" 2>&1)"
+            echo "$output"
+
+            if ! grep -Fq "Succeeded" <<< "$output"; then
+              echo "$file signature verification failed"
+              exit 1
+            fi
+          }
+
+          verify_signature build/appwrite-cli-win-x64.exe
+          verify_signature build/appwrite-cli-win-arm64.exe
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## 21.0.0
+
+* Breaking: Renamed `project update-canonical-emails`, `update-disposable-emails`, and `update-free-emails` to `update-deny-canonical-email-policy`, `update-deny-disposable-email-policy`, and `update-deny-free-email-policy`
+* Breaking: Renamed `proxy update-rule-verification` to `proxy update-rule-status`
+* Breaking: Renamed `--provider` to `--provider-id` on `project get-o-auth-2-provider`
+* Breaking: Made `--variable-id` required on `functions create-variable` and `sites create-variable`
+* Added: Introduced `bigint` create/update commands for legacy Databases attributes
+* Added: Introduced `bigint` create/update commands for `TablesDB` columns
+* Added: Added `--on-duplicate` flag on `tablesdb upsert-row`, `create-rows`, and `upsert-rows`
+* Added: Added `--limit` flag on `vcs list-repository-branches`
+* Added: Code-signed Windows release binaries (`appwrite-cli-win-x64.exe` and `appwrite-cli-win-arm64.exe`) via SignPath
+* Updated: Extended key-list query filters with `key`, `resourceType`, `resourceId`, and `secret`
+* Updated: Changed default `--duration` on `project create-ephemeral-key` from `1` to `600` seconds
+
 ## 20.1.0
 
 * Added `--switch` and `--new` flags on `appwrite login` to explicitly manage multiple saved accounts

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Appwrite Command Line SDK
 
 ![License](https://img.shields.io/github/license/appwrite/sdk-for-cli.svg?style=flat-square)
-![Version](https://img.shields.io/badge/api%20version-1.9.3-blue.svg?style=flat-square)
+![Version](https://img.shields.io/badge/api%20version-1.9.4-blue.svg?style=flat-square)
 [![Build Status](https://img.shields.io/travis/com/appwrite/sdk-generator?style=flat-square)](https://travis-ci.com/appwrite/sdk-generator)
 [![Twitter Account](https://img.shields.io/twitter/follow/appwrite?color=00acee&label=twitter&style=flat-square)](https://twitter.com/appwrite)
 [![Discord](https://img.shields.io/discord/564160730845151244?label=discord&style=flat-square)](https://appwrite.io/discord)
@@ -29,7 +29,7 @@ Once the installation is complete, you can verify the install using
 
 ```sh
 $ appwrite -v
-20.1.0
+21.0.0
 ```
 
 ### Install using prebuilt binaries
@@ -83,7 +83,7 @@ $ scoop install https://raw.githubusercontent.com/appwrite/sdk-for-cli/master/sc
 Once the installation completes, you can verify your install using
 ```
 $ appwrite -v
-20.1.0
+21.0.0
 ```
 
 ## Getting Started 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "appwrite-cli",
       "dependencies": {
-        "@appwrite.io/console": "12.0.0",
+        "@appwrite.io/console": "12.1.0",
         "chalk": "4.1.2",
         "chokidar": "^3.6.0",
         "cli-progress": "^3.12.0",
@@ -51,7 +51,7 @@
     "tmp": "0.2.5",
   },
   "packages": {
-    "@appwrite.io/console": ["@appwrite.io/console@12.0.0", "", { "dependencies": { "json-bigint": "1.0.0" } }, "sha512-lvB4z53DvUh6zPRZP7F2nbhdu5WbdqA+cJO6aCqSjZ9egqETOKOrMl6M7UtmPO6TkxM2CGsDVNf5pYDECletqg=="],
+    "@appwrite.io/console": ["@appwrite.io/console@12.1.0", "", { "dependencies": { "json-bigint": "1.0.0" } }, "sha512-pfI4UYCxEo8sGfub6UDDsQZxBu3b38x4d+SIQsZifRvKqCW+F7WRStxSQie6phw5dQaw/5SyEMEGhzURtj2MfQ=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -273,25 +273,25 @@
 
     "@types/through": ["@types/through@0.0.33", "", { "dependencies": { "@types/node": "*" } }, "sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ=="],
 
-    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.59.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.59.1", "@typescript-eslint/type-utils": "8.59.1", "@typescript-eslint/utils": "8.59.1", "@typescript-eslint/visitor-keys": "8.59.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.59.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag=="],
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.59.2", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.59.2", "@typescript-eslint/type-utils": "8.59.2", "@typescript-eslint/utils": "8.59.2", "@typescript-eslint/visitor-keys": "8.59.2", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.59.2", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ=="],
 
-    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.59.1", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.59.1", "@typescript-eslint/types": "8.59.1", "@typescript-eslint/typescript-estree": "8.59.1", "@typescript-eslint/visitor-keys": "8.59.1", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA=="],
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.59.2", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.59.2", "@typescript-eslint/types": "8.59.2", "@typescript-eslint/typescript-estree": "8.59.2", "@typescript-eslint/visitor-keys": "8.59.2", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ=="],
 
-    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.59.1", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.59.1", "@typescript-eslint/types": "^8.59.1", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg=="],
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.59.2", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.59.2", "@typescript-eslint/types": "^8.59.2", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw=="],
 
-    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.59.1", "", { "dependencies": { "@typescript-eslint/types": "8.59.1", "@typescript-eslint/visitor-keys": "8.59.1" } }, "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg=="],
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.59.2", "", { "dependencies": { "@typescript-eslint/types": "8.59.2", "@typescript-eslint/visitor-keys": "8.59.2" } }, "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg=="],
 
-    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.59.1", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA=="],
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.59.2", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw=="],
 
-    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.59.1", "", { "dependencies": { "@typescript-eslint/types": "8.59.1", "@typescript-eslint/typescript-estree": "8.59.1", "@typescript-eslint/utils": "8.59.1", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-klWPBR2ciQHS3f++ug/mVnWKPjBUo7icEL3FAO1lhAR1Z1i5NQYZ1EannMSRYcq5qCv5wNALlXr6fksRHyYl7w=="],
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.59.2", "", { "dependencies": { "@typescript-eslint/types": "8.59.2", "@typescript-eslint/typescript-estree": "8.59.2", "@typescript-eslint/utils": "8.59.2", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ=="],
 
-    "@typescript-eslint/types": ["@typescript-eslint/types@8.59.1", "", {}, "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A=="],
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.59.2", "", {}, "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q=="],
 
-    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.59.1", "", { "dependencies": { "@typescript-eslint/project-service": "8.59.1", "@typescript-eslint/tsconfig-utils": "8.59.1", "@typescript-eslint/types": "8.59.1", "@typescript-eslint/visitor-keys": "8.59.1", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g=="],
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.59.2", "", { "dependencies": { "@typescript-eslint/project-service": "8.59.2", "@typescript-eslint/tsconfig-utils": "8.59.2", "@typescript-eslint/types": "8.59.2", "@typescript-eslint/visitor-keys": "8.59.2", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg=="],
 
-    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.59.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.59.1", "@typescript-eslint/types": "8.59.1", "@typescript-eslint/typescript-estree": "8.59.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA=="],
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.59.2", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.59.2", "@typescript-eslint/types": "8.59.2", "@typescript-eslint/typescript-estree": "8.59.2" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q=="],
 
-    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.59.1", "", { "dependencies": { "@typescript-eslint/types": "8.59.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg=="],
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.59.2", "", { "dependencies": { "@typescript-eslint/types": "8.59.2", "eslint-visitor-keys": "^5.0.0" } }, "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA=="],
 
     "@xmldom/xmldom": ["@xmldom/xmldom@0.9.10", "", {}, "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw=="],
 
@@ -341,7 +341,7 @@
 
     "bare-stream": ["bare-stream@2.13.1", "", { "dependencies": { "streamx": "^2.25.0", "teex": "^1.0.1" }, "peerDependencies": { "bare-abort-controller": "*", "bare-buffer": "*", "bare-events": "*" }, "optionalPeers": ["bare-abort-controller", "bare-buffer"] }, "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow=="],
 
-    "bare-url": ["bare-url@2.4.2", "", { "dependencies": { "bare-path": "^3.0.0" } }, "sha512-/9a2j4ac6ckpmAHvod/ob7x439OAHst/drc2Clnq+reRYd/ovddwcF4LfoxHyNk5AuGBnPg+HqFjmE/Zpq6v0A=="],
+    "bare-url": ["bare-url@2.4.3", "", { "dependencies": { "bare-path": "^3.0.0" } }, "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ=="],
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
@@ -567,7 +567,7 @@
 
     "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
 
-    "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
+    "is-core-module": ["is-core-module@2.16.2", "", { "dependencies": { "hasown": "^2.0.3" } }, "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
@@ -665,7 +665,7 @@
 
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
 
-    "node-abi": ["node-abi@3.90.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-pZNQT7UnYlMwMBy5N1lV5X/YLTbZM5ncytN3xL7CHEzhDN8uVe0u55yaPUJICIJjaCW8NrM5BFdqr7HLweStNA=="],
+    "node-abi": ["node-abi@3.91.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-B+S7X/GS3Un6wMICtnsNjQD7oSpVBQrZftHE6GZ1Fe9/k3XOOoqbM5DZZ0GO4x3YiSCQfrM28yj1ppplwgIsfg=="],
 
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
@@ -813,7 +813,7 @@
 
     "tail": ["tail@2.2.6", "", {}, "sha512-IQ6G4wK/t8VBauYiGPLx+d3fA5XjSVagjWV5SIYzvEvglbQjwEcukeYI68JOPpdydjxhZ9sIgzRlSmwSpphHyw=="],
 
-    "tar": ["tar@7.5.13", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng=="],
+    "tar": ["tar@7.5.14", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-/7sHKgQO3JLP9ESlwTYUUftHUadOURUqq23xs1vjcnp8Vss6k0wCfzulyEtk5g91pjvnuriimGlyG7k6msrzRw=="],
 
     "tar-fs": ["tar-fs@3.1.2", "", { "dependencies": { "pump": "^3.0.0", "tar-stream": "^3.1.5" }, "optionalDependencies": { "bare-fs": "^4.0.1", "bare-path": "^3.0.0" } }, "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw=="],
 
@@ -857,7 +857,7 @@
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "typescript-eslint": ["typescript-eslint@8.59.1", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.59.1", "@typescript-eslint/parser": "8.59.1", "@typescript-eslint/typescript-estree": "8.59.1", "@typescript-eslint/utils": "8.59.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-xqDcFVBmlrltH64lklOVp1wYxgJr6LVdg3NamBgH2OOQDLFdTKfIZXF5PfghrnXQKXZGTQs8tr1vL7fJvq8CTQ=="],
+    "typescript-eslint": ["typescript-eslint@8.59.2", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.59.2", "@typescript-eslint/parser": "8.59.2", "@typescript-eslint/typescript-estree": "8.59.2", "@typescript-eslint/utils": "8.59.2" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ=="],
 
     "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
 

--- a/docs/examples/databases/create-big-int-attribute.md
+++ b/docs/examples/databases/create-big-int-attribute.md
@@ -1,0 +1,7 @@
+```bash
+appwrite databases create-big-int-attribute \
+    --database-id <DATABASE_ID> \
+    --collection-id <COLLECTION_ID> \
+    --key '' \
+    --required false
+```

--- a/docs/examples/databases/update-big-int-attribute.md
+++ b/docs/examples/databases/update-big-int-attribute.md
@@ -1,0 +1,8 @@
+```bash
+appwrite databases update-big-int-attribute \
+    --database-id <DATABASE_ID> \
+    --collection-id <COLLECTION_ID> \
+    --key '' \
+    --required false \
+    --default null
+```

--- a/docs/examples/functions/create-variable.md
+++ b/docs/examples/functions/create-variable.md
@@ -1,6 +1,7 @@
 ```bash
 appwrite functions create-variable \
     --function-id <FUNCTION_ID> \
+    --variable-id <VARIABLE_ID> \
     --key <KEY> \
     --value <VALUE>
 ```

--- a/docs/examples/functions/list-variables.md
+++ b/docs/examples/functions/list-variables.md
@@ -1,4 +1,5 @@
 ```bash
 appwrite functions list-variables \
-    --function-id <FUNCTION_ID>
+    --function-id <FUNCTION_ID> \
+    --limit 25
 ```

--- a/docs/examples/functions/update-variable.md
+++ b/docs/examples/functions/update-variable.md
@@ -1,6 +1,5 @@
 ```bash
 appwrite functions update-variable \
     --function-id <FUNCTION_ID> \
-    --variable-id <VARIABLE_ID> \
-    --key <KEY>
+    --variable-id <VARIABLE_ID>
 ```

--- a/docs/examples/project/create-ephemeral-key.md
+++ b/docs/examples/project/create-ephemeral-key.md
@@ -1,5 +1,5 @@
 ```bash
 appwrite project create-ephemeral-key \
     --scopes one two three \
-    --duration 1
+    --duration 600
 ```

--- a/docs/examples/project/get-o-auth-2-provider.md
+++ b/docs/examples/project/get-o-auth-2-provider.md
@@ -1,4 +1,4 @@
 ```bash
 appwrite project get-o-auth-2-provider \
-    --provider <PROVIDER>
+    --provider-id amazon
 ```

--- a/docs/examples/project/list-o-auth-2-providers.md
+++ b/docs/examples/project/list-o-auth-2-providers.md
@@ -1,3 +1,4 @@
 ```bash
-appwrite project list-o-auth-2-providers
+appwrite project list-o-auth-2-providers \
+    --limit 25
 ```

--- a/docs/examples/project/update-canonical-emails.md
+++ b/docs/examples/project/update-canonical-emails.md
@@ -1,4 +1,0 @@
-```bash
-appwrite project update-canonical-emails \
-    --enabled false
-```

--- a/docs/examples/project/update-deny-canonical-email-policy.md
+++ b/docs/examples/project/update-deny-canonical-email-policy.md
@@ -1,0 +1,4 @@
+```bash
+appwrite project update-deny-canonical-email-policy \
+    --enabled false
+```

--- a/docs/examples/project/update-deny-disposable-email-policy.md
+++ b/docs/examples/project/update-deny-disposable-email-policy.md
@@ -1,0 +1,4 @@
+```bash
+appwrite project update-deny-disposable-email-policy \
+    --enabled false
+```

--- a/docs/examples/project/update-deny-free-email-policy.md
+++ b/docs/examples/project/update-deny-free-email-policy.md
@@ -1,0 +1,4 @@
+```bash
+appwrite project update-deny-free-email-policy \
+    --enabled false
+```

--- a/docs/examples/project/update-disposable-emails.md
+++ b/docs/examples/project/update-disposable-emails.md
@@ -1,4 +1,0 @@
-```bash
-appwrite project update-disposable-emails \
-    --enabled false
-```

--- a/docs/examples/project/update-free-emails.md
+++ b/docs/examples/project/update-free-emails.md
@@ -1,4 +1,0 @@
-```bash
-appwrite project update-free-emails \
-    --enabled false
-```

--- a/docs/examples/proxy/update-rule-status.md
+++ b/docs/examples/proxy/update-rule-status.md
@@ -1,0 +1,4 @@
+```bash
+appwrite proxy update-rule-status \
+    --rule-id <RULE_ID>
+```

--- a/docs/examples/proxy/update-rule-verification.md
+++ b/docs/examples/proxy/update-rule-verification.md
@@ -1,4 +1,0 @@
-```bash
-appwrite proxy update-rule-verification \
-    --rule-id <RULE_ID>
-```

--- a/docs/examples/sites/create-variable.md
+++ b/docs/examples/sites/create-variable.md
@@ -1,6 +1,7 @@
 ```bash
 appwrite sites create-variable \
     --site-id <SITE_ID> \
+    --variable-id <VARIABLE_ID> \
     --key <KEY> \
     --value <VALUE>
 ```

--- a/docs/examples/sites/list-variables.md
+++ b/docs/examples/sites/list-variables.md
@@ -1,4 +1,5 @@
 ```bash
 appwrite sites list-variables \
-    --site-id <SITE_ID>
+    --site-id <SITE_ID> \
+    --limit 25
 ```

--- a/docs/examples/sites/update-variable.md
+++ b/docs/examples/sites/update-variable.md
@@ -1,6 +1,5 @@
 ```bash
 appwrite sites update-variable \
     --site-id <SITE_ID> \
-    --variable-id <VARIABLE_ID> \
-    --key <KEY>
+    --variable-id <VARIABLE_ID>
 ```

--- a/docs/examples/tablesdb/create-big-int-column.md
+++ b/docs/examples/tablesdb/create-big-int-column.md
@@ -1,0 +1,7 @@
+```bash
+appwrite tables-db create-big-int-column \
+    --database-id <DATABASE_ID> \
+    --table-id <TABLE_ID> \
+    --key '' \
+    --required false
+```

--- a/docs/examples/tablesdb/update-big-int-column.md
+++ b/docs/examples/tablesdb/update-big-int-column.md
@@ -1,0 +1,8 @@
+```bash
+appwrite tables-db update-big-int-column \
+    --database-id <DATABASE_ID> \
+    --table-id <TABLE_ID> \
+    --key '' \
+    --required false \
+    --default null
+```

--- a/docs/examples/vcs/list-repository-branches.md
+++ b/docs/examples/vcs/list-repository-branches.md
@@ -1,5 +1,6 @@
 ```bash
 appwrite vcs list-repository-branches \
     --installation-id <INSTALLATION_ID> \
-    --provider-repository-id <PROVIDER_REPOSITORY_ID>
+    --provider-repository-id <PROVIDER_REPOSITORY_ID> \
+    --limit 25
 ```

--- a/install.ps1
+++ b/install.ps1
@@ -13,8 +13,8 @@
 # You can use "View source" of this page to see the full script.
 
 # REPO
-$GITHUB_x64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/20.1.0/appwrite-cli-win-x64.exe"
-$GITHUB_arm64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/20.1.0/appwrite-cli-win-arm64.exe"
+$GITHUB_x64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/21.0.0/appwrite-cli-win-x64.exe"
+$GITHUB_arm64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/21.0.0/appwrite-cli-win-arm64.exe"
 
 $APPWRITE_BINARY_NAME = "appwrite.exe"
 

--- a/install.sh
+++ b/install.sh
@@ -120,7 +120,7 @@ verifyMacOSCodeSignature() {
 downloadBinary() {
     echo "[2/5] Downloading executable for $OS ($ARCH) ..."
 
-    GITHUB_LATEST_VERSION="20.1.0"
+    GITHUB_LATEST_VERSION="21.0.0"
     GITHUB_FILE="appwrite-cli-${OS}-${ARCH}"
     GITHUB_URL="https://github.com/$GITHUB_REPOSITORY_NAME/releases/download/$GITHUB_LATEST_VERSION/$GITHUB_FILE"
 

--- a/lib/commands/init.ts
+++ b/lib/commands/init.ts
@@ -136,9 +136,7 @@ const printInitProjectNextSteps = (steps: InitProjectNextStep[]): void => {
 
   for (const step of steps) {
     const spacing = " ".repeat(longestCommand - step.command.length + 4);
-    console.log(
-      `    ${chalk.cyan(step.command)}${spacing}${step.description}`,
-    );
+    console.log(`    ${chalk.cyan(step.command)}${spacing}${step.description}`);
   }
 };
 

--- a/lib/commands/push.ts
+++ b/lib/commands/push.ts
@@ -153,9 +153,7 @@ function getDeploymentProgressSignature(
   const status =
     typeof deployment["status"] === "string" ? deployment["status"] : "";
   const buildLogs =
-    typeof deployment["buildLogs"] === "string"
-      ? deployment["buildLogs"]
-      : "";
+    typeof deployment["buildLogs"] === "string" ? deployment["buildLogs"] : "";
   const updatedAt =
     typeof deployment["$updatedAt"] === "string"
       ? deployment["$updatedAt"]
@@ -173,9 +171,7 @@ function getDeploymentProgressSignature(
   });
 }
 
-function createDeploymentTimeoutTracker(
-  deployment: Record<string, unknown>,
-): {
+function createDeploymentTimeoutTracker(deployment: Record<string, unknown>): {
   touch: (deployment: Record<string, unknown>) => void;
   hasTimedOut: () => boolean;
 } {

--- a/lib/commands/services/databases.ts
+++ b/lib/commands/services/databases.ts
@@ -367,6 +367,51 @@ const databasesListAttributesCommand = databases
   );
 
 
+const databasesCreateBigIntAttributeCommand = databases
+  .command(`create-big-int-attribute`)
+  .description(`Create a bigint attribute. Optionally, minimum and maximum values can be provided.
+`)
+  .requiredOption(`--database-id <database-id>`, `Database ID.`)
+  .requiredOption(`--collection-id <collection-id>`, `Collection ID.`)
+  .requiredOption(`--key <key>`, `Attribute Key.`)
+  .requiredOption(`--required <required>`, `Is attribute required?`, parseBool)
+  .option(`--min <min>`, `Minimum value`, parseInteger)
+  .option(`--max <max>`, `Maximum value`, parseInteger)
+  .option(`--xdefault <xdefault>`, `Default value. Cannot be set when attribute is required.`, parseInteger)
+  .option(
+    `--array [value]`,
+    `Is attribute an array?`,
+    (value: string | undefined) =>
+      value === undefined ? true : parseBool(value),
+  )
+  .action(
+    actionRunner(
+      async ({ databaseId, collectionId, key, required, min, max, xdefault, array }) =>
+        parse(await (await getDatabasesClient()).createBigIntAttribute(databaseId, collectionId, key, required, min, max, xdefault, array)),
+    ),
+  );
+
+
+const databasesUpdateBigIntAttributeCommand = databases
+  .command(`update-big-int-attribute`)
+  .description(`Update a bigint attribute. Changing the \`default\` value will not update already existing documents.
+`)
+  .requiredOption(`--database-id <database-id>`, `Database ID.`)
+  .requiredOption(`--collection-id <collection-id>`, `Collection ID.`)
+  .requiredOption(`--key <key>`, `Attribute Key.`)
+  .requiredOption(`--required <required>`, `Is attribute required?`, parseBool)
+  .requiredOption(`--xdefault <xdefault>`, `Default value. Cannot be set when attribute is required.`, parseInteger)
+  .option(`--min <min>`, `Minimum value`, parseInteger)
+  .option(`--max <max>`, `Maximum value`, parseInteger)
+  .option(`--new-key <new-key>`, `New Attribute Key.`)
+  .action(
+    actionRunner(
+      async ({ databaseId, collectionId, key, required, xdefault, min, max, newKey }) =>
+        parse(await (await getDatabasesClient()).updateBigIntAttribute(databaseId, collectionId, key, required, xdefault, min, max, newKey)),
+    ),
+  );
+
+
 const databasesCreateBooleanAttributeCommand = databases
   .command(`create-boolean-attribute`)
   .description(`Create a boolean attribute.

--- a/lib/commands/services/functions.ts
+++ b/lib/commands/services/functions.ts
@@ -513,10 +513,24 @@ const functionsListVariablesCommand = functions
   .command(`list-variables`)
   .description(`Get a list of all variables of a specific function.`)
   .requiredOption(`--function-id <function-id>`, `Function unique ID.`)
+  .option(`--queries [queries...]`, `Raw Appwrite JSON query strings (legacy). Use this for advanced queries or automation; for common filtering, sorting, and pagination prefer --where, --sort-asc, --sort-desc, --limit, and --offset. When mixed, raw --queries are sent before generated flag queries. Array of query strings generated using the Query class provided by the SDK. Learn more about queries (https://appwrite.io/docs/queries). Maximum of 100 queries are allowed, each 4096 characters long. You may filter on the following attributes: key, resourceType, resourceId, secret`)
+  .option(
+    `--total [value]`,
+    `When set to false, the total count returned will be 0 and will not be calculated.`,
+    (value: string | undefined) =>
+      value === undefined ? true : parseBool(value),
+  )
+  .option(`--where <expression>`, `Filter using a simple comparison expression. Repeat for multiple filters. Supports field=value, field!=value, field>value, field>=value, field<value, and field<=value.`, (value: string, previous: string[] | undefined) => collectQueryValue(parseWhereQuery(value), previous))
+  .option(`--sort-asc <attribute>`, `Sort results by an attribute in ascending order. Repeat for multiple sort fields.`, (value: string, previous: string[] | undefined) => collectQueryValue(value, previous))
+  .option(`--sort-desc <attribute>`, `Sort results by an attribute in descending order. Repeat for multiple sort fields.`, (value: string, previous: string[] | undefined) => collectQueryValue(value, previous))
+  .option(`--limit <limit>`, `Maximum number of results to return.`, parseInteger)
+  .option(`--offset <offset>`, `Number of results to skip.`, parseInteger)
+  .option(`--cursor-after <id>`, `Return results after this cursor ID.`)
+  .option(`--cursor-before <id>`, `Return results before this cursor ID.`)
   .action(
     actionRunner(
-      async ({ functionId }) =>
-        parse(await (await getFunctionsClient()).listVariables(functionId)),
+      async ({ functionId, queries, total, where, sortAsc, sortDesc, cursorAfter, cursorBefore, limit, offset }) =>
+        parse(await (await getFunctionsClient()).listVariables(functionId, buildQueries({ queries, where, sortAsc, sortDesc, cursorAfter, cursorBefore, limit, offset }), total)),
     ),
   );
 
@@ -525,6 +539,7 @@ const functionsCreateVariableCommand = functions
   .command(`create-variable`)
   .description(`Create a new function environment variable. These variables can be accessed in the function at runtime as environment variables.`)
   .requiredOption(`--function-id <function-id>`, `Function unique ID.`)
+  .requiredOption(`--variable-id <variable-id>`, `Variable ID. Choose a custom ID or generate a random ID with \`ID.unique()\`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can't start with a special char. Max length is 36 chars.`)
   .requiredOption(`--key <key>`, `Variable key. Max length: 255 chars.`)
   .requiredOption(`--value <value>`, `Variable value. Max length: 8192 chars.`)
   .option(
@@ -535,8 +550,8 @@ const functionsCreateVariableCommand = functions
   )
   .action(
     actionRunner(
-      async ({ functionId, key, value, secret }) =>
-        parse(await (await getFunctionsClient()).createVariable(functionId, key, value, secret)),
+      async ({ functionId, variableId, key, value, secret }) =>
+        parse(await (await getFunctionsClient()).createVariable(functionId, variableId, key, value, secret)),
     ),
   );
 
@@ -559,7 +574,7 @@ const functionsUpdateVariableCommand = functions
   .description(`Update variable by its unique ID.`)
   .requiredOption(`--function-id <function-id>`, `Function unique ID.`)
   .requiredOption(`--variable-id <variable-id>`, `Variable unique ID.`)
-  .requiredOption(`--key <key>`, `Variable key. Max length: 255 chars.`)
+  .option(`--key <key>`, `Variable key. Max length: 255 chars.`)
   .option(`--value <value>`, `Variable value. Max length: 8192 chars.`)
   .option(
     `--secret [value]`,

--- a/lib/commands/services/migrations.ts
+++ b/lib/commands/services/migrations.ts
@@ -64,10 +64,11 @@ const migrationsCreateAppwriteMigrationCommand = migrations
   .requiredOption(`--endpoint <endpoint>`, `Source Appwrite endpoint`)
   .requiredOption(`--project-id <project-id>`, `Source Project ID`)
   .requiredOption(`--api-key <api-key>`, `Source API Key`)
+  .option(`--on-duplicate <on-duplicate>`, `Behavior when a row with an existing $id is encountered. "fail" (default): abort on first conflict. "skip": silently ignore. "overwrite": replace existing row.`)
   .action(
     actionRunner(
-      async ({ resources, endpoint, projectId, apiKey }) =>
-        parse(await (await getMigrationsClient()).createAppwriteMigration(resources, endpoint, projectId, apiKey)),
+      async ({ resources, endpoint, projectId, apiKey, onDuplicate }) =>
+        parse(await (await getMigrationsClient()).createAppwriteMigration(resources, endpoint, projectId, apiKey, onDuplicate)),
     ),
   );
 
@@ -136,10 +137,11 @@ const migrationsCreateCSVImportCommand = migrations
     (value: string | undefined) =>
       value === undefined ? true : parseBool(value),
   )
+  .option(`--on-duplicate <on-duplicate>`, `Behavior when a row with an existing $id is encountered. "fail" (default): abort on first conflict. "skip": silently ignore. "overwrite": replace existing row.`)
   .action(
     actionRunner(
-      async ({ bucketId, fileId, resourceId, internalFile }) =>
-        parse(await (await getMigrationsClient()).createCSVImport(bucketId, fileId, resourceId, internalFile)),
+      async ({ bucketId, fileId, resourceId, internalFile, onDuplicate }) =>
+        parse(await (await getMigrationsClient()).createCSVImport(bucketId, fileId, resourceId, internalFile, onDuplicate)),
     ),
   );
 
@@ -212,10 +214,11 @@ const migrationsCreateJSONImportCommand = migrations
     (value: string | undefined) =>
       value === undefined ? true : parseBool(value),
   )
+  .option(`--on-duplicate <on-duplicate>`, `Behavior when a row with an existing $id is encountered. "fail" (default): abort on first conflict. "skip": silently ignore. "overwrite": replace existing row.`)
   .action(
     actionRunner(
-      async ({ bucketId, fileId, resourceId, internalFile }) =>
-        parse(await (await getMigrationsClient()).createJSONImport(bucketId, fileId, resourceId, internalFile)),
+      async ({ bucketId, fileId, resourceId, internalFile, onDuplicate }) =>
+        parse(await (await getMigrationsClient()).createJSONImport(bucketId, fileId, resourceId, internalFile, onDuplicate)),
     ),
   );
 

--- a/lib/commands/services/project.ts
+++ b/lib/commands/services/project.ts
@@ -54,42 +54,6 @@ const projectUpdateAuthMethodCommand = project
   );
 
 
-const projectUpdateCanonicalEmailsCommand = project
-  .command(`update-canonical-emails`)
-  .description(`Configure if canonical emails (alias subaddresses and emails with suffixes) are allowed during new users sign-ups in this project.`)
-  .requiredOption(`--enabled <enabled>`, `Set whether or not to require canonical email addresses during signup and email updates.`, parseBool)
-  .action(
-    actionRunner(
-      async ({ enabled }) =>
-        parse(await (await getProjectClient()).updateCanonicalEmails(enabled)),
-    ),
-  );
-
-
-const projectUpdateDisposableEmailsCommand = project
-  .command(`update-disposable-emails`)
-  .description(`Configure if disposable emails (emails of known temporary domains) are allowed during new users sign-ups in this project.`)
-  .requiredOption(`--enabled <enabled>`, `Set whether or not to block disposable email addresses during signup and email updates.`, parseBool)
-  .action(
-    actionRunner(
-      async ({ enabled }) =>
-        parse(await (await getProjectClient()).updateDisposableEmails(enabled)),
-    ),
-  );
-
-
-const projectUpdateFreeEmailsCommand = project
-  .command(`update-free-emails`)
-  .description(`Configure if free emails (non-commercial and not a custom domain) are allowed during new users sign-ups in this project.`)
-  .requiredOption(`--enabled <enabled>`, `Set whether or not to block free email addresses during signup and email updates.`, parseBool)
-  .action(
-    actionRunner(
-      async ({ enabled }) =>
-        parse(await (await getProjectClient()).updateFreeEmails(enabled)),
-    ),
-  );
-
-
 const projectListKeysCommand = project
   .command(`list-keys`)
   .description(`Get a list of all API keys from the current project.`)
@@ -271,9 +235,19 @@ const projectDeleteMockPhoneCommand = project
 const projectListOAuth2ProvidersCommand = project
   .command(`list-o-auth-2-providers`)
   .description(`Get a list of all OAuth2 providers supported by the server, along with the project's configuration for each. Credential fields are write-only and always returned empty.`)
+  .option(`--queries [queries...]`, `Raw Appwrite JSON query strings (legacy). Use this for advanced queries or automation; for common pagination prefer --limit and --offset. When mixed, raw --queries are sent before generated flag queries. Array of query strings generated using the Query class provided by the SDK. Learn more about queries (https://appwrite.io/docs/queries). Only supported methods are limit and offset`)
+  .option(
+    `--total [value]`,
+    `When set to false, the total count returned will be 0 and will not be calculated.`,
+    (value: string | undefined) =>
+      value === undefined ? true : parseBool(value),
+  )
+  .option(`--limit <limit>`, `Maximum number of results to return.`, parseInteger)
+  .option(`--offset <offset>`, `Number of results to skip.`, parseInteger)
   .action(
     actionRunner(
-      async () => parse(await (await getProjectClient()).listOAuth2Providers()),
+      async ({ queries, total, limit, offset }) =>
+        parse(await (await getProjectClient()).listOAuth2Providers(buildQueries({ queries, limit, offset }), total)),
     ),
   );
 
@@ -1094,11 +1068,11 @@ const projectUpdateOAuth2ZoomCommand = project
 const projectGetOAuth2ProviderCommand = project
   .command(`get-o-auth-2-provider`)
   .description(`Get a single OAuth2 provider configuration. Credential fields (client secret, p8 file, key/team IDs) are write-only and always returned empty.`)
-  .requiredOption(`--provider <provider>`, `OAuth2 provider key. For example: github, google, apple.`)
+  .requiredOption(`--provider-id <provider-id>`, `OAuth2 provider key. For example: github, google, apple.`)
   .action(
     actionRunner(
-      async ({ provider }) =>
-        parse(await (await getProjectClient()).getOAuth2Provider(provider)),
+      async ({ providerId }) =>
+        parse(await (await getProjectClient()).getOAuth2Provider(providerId)),
     ),
   );
 
@@ -1308,6 +1282,42 @@ const projectListPoliciesCommand = project
     actionRunner(
       async ({ queries, total, limit, offset }) =>
         parse(await (await getProjectClient()).listPolicies(buildQueries({ queries, limit, offset }), total)),
+    ),
+  );
+
+
+const projectUpdateDenyCanonicalEmailPolicyCommand = project
+  .command(`update-deny-canonical-email-policy`)
+  .description(`Configures if email aliases such as subaddresses and emails with suffixes are denied during new users sign-ups and email updates.`)
+  .requiredOption(`--enabled <enabled>`, `Set whether or not to block email aliases during signup and email updates.`, parseBool)
+  .action(
+    actionRunner(
+      async ({ enabled }) =>
+        parse(await (await getProjectClient()).updateDenyCanonicalEmailPolicy(enabled)),
+    ),
+  );
+
+
+const projectUpdateDenyDisposableEmailPolicyCommand = project
+  .command(`update-deny-disposable-email-policy`)
+  .description(`Configures if disposable emails from known temporary domains are denied during new users sign-ups and email updates.`)
+  .requiredOption(`--enabled <enabled>`, `Set whether or not to block disposable email addresses during signup and email updates.`, parseBool)
+  .action(
+    actionRunner(
+      async ({ enabled }) =>
+        parse(await (await getProjectClient()).updateDenyDisposableEmailPolicy(enabled)),
+    ),
+  );
+
+
+const projectUpdateDenyFreeEmailPolicyCommand = project
+  .command(`update-deny-free-email-policy`)
+  .description(`Configures if emails from free providers such as Gmail or Yahoo are denied during new users sign-ups and email updates.`)
+  .requiredOption(`--enabled <enabled>`, `Set whether or not to block free email addresses during signup and email updates.`, parseBool)
+  .action(
+    actionRunner(
+      async ({ enabled }) =>
+        parse(await (await getProjectClient()).updateDenyFreeEmailPolicy(enabled)),
     ),
   );
 
@@ -1621,7 +1631,7 @@ const projectListVariablesCommand = project
 const projectCreateVariableCommand = project
   .command(`create-variable`)
   .description(`Create a new project environment variable. These variables can be accessed by all functions and sites in the project.`)
-  .requiredOption(`--variable-id <variable-id>`, `Variable ID. Choose a custom ID or generate a random ID with \`ID.unique()\`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can't start with a special char. Max length is 36 chars.`)
+  .requiredOption(`--variable-id <variable-id>`, `Variable unique ID. Choose a custom ID or generate a random ID with \`ID.unique()\`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can't start with a special char. Max length is 36 chars.`)
   .requiredOption(`--key <key>`, `Variable key. Max length: 255 chars.`)
   .requiredOption(`--value <value>`, `Variable value. Max length: 8192 chars.`)
   .option(
@@ -1641,7 +1651,7 @@ const projectCreateVariableCommand = project
 const projectGetVariableCommand = project
   .command(`get-variable`)
   .description(`Get a variable by its unique ID. `)
-  .requiredOption(`--variable-id <variable-id>`, `Variable ID.`)
+  .requiredOption(`--variable-id <variable-id>`, `Variable unique ID.`)
   .action(
     actionRunner(
       async ({ variableId }) =>
@@ -1653,7 +1663,7 @@ const projectGetVariableCommand = project
 const projectUpdateVariableCommand = project
   .command(`update-variable`)
   .description(`Update variable by its unique ID.`)
-  .requiredOption(`--variable-id <variable-id>`, `Variable ID.`)
+  .requiredOption(`--variable-id <variable-id>`, `Variable unique ID.`)
   .option(`--key <key>`, `Variable key. Max length: 255 chars.`)
   .option(`--value <value>`, `Variable value. Max length: 8192 chars.`)
   .option(
@@ -1673,7 +1683,7 @@ const projectUpdateVariableCommand = project
 const projectDeleteVariableCommand = project
   .command(`delete-variable`)
   .description(`Delete a variable by its unique ID. `)
-  .requiredOption(`--variable-id <variable-id>`, `Variable ID.`)
+  .requiredOption(`--variable-id <variable-id>`, `Variable unique ID.`)
   .action(
     actionRunner(
       async ({ variableId }) =>

--- a/lib/commands/services/proxy.ts
+++ b/lib/commands/services/proxy.ts
@@ -35,7 +35,6 @@ const proxyListRulesCommand = proxy
   .command(`list-rules`)
   .description(`Get a list of all the proxy rules. You can use the query params to filter your results.`)
   .option(`--queries [queries...]`, `Raw Appwrite JSON query strings (legacy). Use this for advanced queries or automation; for common filtering, sorting, and pagination prefer --where, --sort-asc, --sort-desc, --limit, and --offset. When mixed, raw --queries are sent before generated flag queries. Array of query strings generated using the Query class provided by the SDK. Learn more about queries (https://appwrite.io/docs/databases#querying-documents). Maximum of 100 queries are allowed, each 4096 characters long. You may filter on the following attributes: domain, type, trigger, deploymentResourceType, deploymentResourceId, deploymentId, deploymentVcsProviderBranch`)
-  .option(`--search <search>`, `Search term to filter your list results. Max length: 256 chars.`)
   .option(
     `--total [value]`,
     `When set to false, the total count returned will be 0 and will not be calculated.`,
@@ -51,15 +50,17 @@ const proxyListRulesCommand = proxy
   .option(`--cursor-before <id>`, `Return results before this cursor ID.`)
   .action(
     actionRunner(
-      async ({ queries, search, total, where, sortAsc, sortDesc, cursorAfter, cursorBefore, limit, offset }) =>
-        parse(await (await getProxyClient()).listRules(buildQueries({ queries, where, sortAsc, sortDesc, cursorAfter, cursorBefore, limit, offset }), search, total)),
+      async ({ queries, total, where, sortAsc, sortDesc, cursorAfter, cursorBefore, limit, offset }) =>
+        parse(await (await getProxyClient()).listRules(buildQueries({ queries, where, sortAsc, sortDesc, cursorAfter, cursorBefore, limit, offset }), total)),
     ),
   );
 
 
 const proxyCreateAPIRuleCommand = proxy
   .command(`create-api-rule`)
-  .description(`Create a new proxy rule for serving Appwrite's API on custom domain.`)
+  .description(`Create a new proxy rule for serving Appwrite's API on custom domain.
+
+Rule ID is automatically generated as MD5 hash of a rule domain for performance purposes.`)
   .requiredOption(`--domain <domain>`, `Domain name.`)
   .action(
     actionRunner(
@@ -71,7 +72,9 @@ const proxyCreateAPIRuleCommand = proxy
 
 const proxyCreateFunctionRuleCommand = proxy
   .command(`create-function-rule`)
-  .description(`Create a new proxy rule for executing Appwrite Function on custom domain.`)
+  .description(`Create a new proxy rule for executing Appwrite Function on custom domain.
+
+Rule ID is automatically generated as MD5 hash of a rule domain for performance purposes.`)
   .requiredOption(`--domain <domain>`, `Domain name.`)
   .requiredOption(`--function-id <function-id>`, `ID of function to be executed.`)
   .option(`--branch <branch>`, `Name of VCS branch to deploy changes automatically`)
@@ -85,7 +88,9 @@ const proxyCreateFunctionRuleCommand = proxy
 
 const proxyCreateRedirectRuleCommand = proxy
   .command(`create-redirect-rule`)
-  .description(`Create a new proxy rule for to redirect from custom domain to another domain.`)
+  .description(`Create a new proxy rule for to redirect from custom domain to another domain.
+
+Rule ID is automatically generated as MD5 hash of a rule domain for performance purposes.`)
   .requiredOption(`--domain <domain>`, `Domain name.`)
   .requiredOption(`--url <url>`, `Target URL of redirection`)
   .requiredOption(`--status-code <status-code>`, `Status code of redirection`)
@@ -101,7 +106,9 @@ const proxyCreateRedirectRuleCommand = proxy
 
 const proxyCreateSiteRuleCommand = proxy
   .command(`create-site-rule`)
-  .description(`Create a new proxy rule for serving Appwrite Site on custom domain.`)
+  .description(`Create a new proxy rule for serving Appwrite Site on custom domain.
+
+Rule ID is automatically generated as MD5 hash of a rule domain for performance purposes.`)
   .requiredOption(`--domain <domain>`, `Domain name.`)
   .requiredOption(`--site-id <site-id>`, `ID of site to be executed.`)
   .option(`--branch <branch>`, `Name of VCS branch to deploy changes automatically`)
@@ -137,14 +144,14 @@ const proxyDeleteRuleCommand = proxy
   );
 
 
-const proxyUpdateRuleVerificationCommand = proxy
-  .command(`update-rule-verification`)
-  .description(`Retry getting verification process of a proxy rule. This endpoint triggers domain verification by checking DNS records (CNAME) against the configured target domain. If verification is successful, a TLS certificate will be automatically provisioned for the domain.`)
+const proxyUpdateRuleStatusCommand = proxy
+  .command(`update-rule-status`)
+  .description(`If not succeeded yet, retry verification process of a proxy rule domain. This endpoint triggers domain verification by checking DNS records. If verification is successful, a TLS certificate will be automatically provisioned for the domain asynchronously in the background.`)
   .requiredOption(`--rule-id <rule-id>`, `Rule ID.`)
   .action(
     actionRunner(
       async ({ ruleId }) =>
-        parse(await (await getProxyClient()).updateRuleVerification(ruleId)),
+        parse(await (await getProxyClient()).updateRuleStatus(ruleId)),
     ),
   );
 

--- a/lib/commands/services/sites.ts
+++ b/lib/commands/services/sites.ts
@@ -486,10 +486,24 @@ const sitesListVariablesCommand = sites
   .command(`list-variables`)
   .description(`Get a list of all variables of a specific site.`)
   .requiredOption(`--site-id <site-id>`, `Site unique ID.`)
+  .option(`--queries [queries...]`, `Raw Appwrite JSON query strings (legacy). Use this for advanced queries or automation; for common filtering, sorting, and pagination prefer --where, --sort-asc, --sort-desc, --limit, and --offset. When mixed, raw --queries are sent before generated flag queries. Array of query strings generated using the Query class provided by the SDK. Learn more about queries (https://appwrite.io/docs/queries). Maximum of 100 queries are allowed, each 4096 characters long. You may filter on the following attributes: key, resourceType, resourceId, secret`)
+  .option(
+    `--total [value]`,
+    `When set to false, the total count returned will be 0 and will not be calculated.`,
+    (value: string | undefined) =>
+      value === undefined ? true : parseBool(value),
+  )
+  .option(`--where <expression>`, `Filter using a simple comparison expression. Repeat for multiple filters. Supports field=value, field!=value, field>value, field>=value, field<value, and field<=value.`, (value: string, previous: string[] | undefined) => collectQueryValue(parseWhereQuery(value), previous))
+  .option(`--sort-asc <attribute>`, `Sort results by an attribute in ascending order. Repeat for multiple sort fields.`, (value: string, previous: string[] | undefined) => collectQueryValue(value, previous))
+  .option(`--sort-desc <attribute>`, `Sort results by an attribute in descending order. Repeat for multiple sort fields.`, (value: string, previous: string[] | undefined) => collectQueryValue(value, previous))
+  .option(`--limit <limit>`, `Maximum number of results to return.`, parseInteger)
+  .option(`--offset <offset>`, `Number of results to skip.`, parseInteger)
+  .option(`--cursor-after <id>`, `Return results after this cursor ID.`)
+  .option(`--cursor-before <id>`, `Return results before this cursor ID.`)
   .action(
     actionRunner(
-      async ({ siteId }) =>
-        parse(await (await getSitesClient()).listVariables(siteId)),
+      async ({ siteId, queries, total, where, sortAsc, sortDesc, cursorAfter, cursorBefore, limit, offset }) =>
+        parse(await (await getSitesClient()).listVariables(siteId, buildQueries({ queries, where, sortAsc, sortDesc, cursorAfter, cursorBefore, limit, offset }), total)),
     ),
   );
 
@@ -498,6 +512,7 @@ const sitesCreateVariableCommand = sites
   .command(`create-variable`)
   .description(`Create a new site variable. These variables can be accessed during build and runtime (server-side rendering) as environment variables.`)
   .requiredOption(`--site-id <site-id>`, `Site unique ID.`)
+  .requiredOption(`--variable-id <variable-id>`, `Variable ID. Choose a custom ID or generate a random ID with \`ID.unique()\`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can't start with a special char. Max length is 36 chars.`)
   .requiredOption(`--key <key>`, `Variable key. Max length: 255 chars.`)
   .requiredOption(`--value <value>`, `Variable value. Max length: 8192 chars.`)
   .option(
@@ -508,8 +523,8 @@ const sitesCreateVariableCommand = sites
   )
   .action(
     actionRunner(
-      async ({ siteId, key, value, secret }) =>
-        parse(await (await getSitesClient()).createVariable(siteId, key, value, secret)),
+      async ({ siteId, variableId, key, value, secret }) =>
+        parse(await (await getSitesClient()).createVariable(siteId, variableId, key, value, secret)),
     ),
   );
 
@@ -532,7 +547,7 @@ const sitesUpdateVariableCommand = sites
   .description(`Update variable by its unique ID.`)
   .requiredOption(`--site-id <site-id>`, `Site unique ID.`)
   .requiredOption(`--variable-id <variable-id>`, `Variable unique ID.`)
-  .requiredOption(`--key <key>`, `Variable key. Max length: 255 chars.`)
+  .option(`--key <key>`, `Variable key. Max length: 255 chars.`)
   .option(`--value <value>`, `Variable value. Max length: 8192 chars.`)
   .option(
     `--secret [value]`,

--- a/lib/commands/services/tables-db.ts
+++ b/lib/commands/services/tables-db.ts
@@ -367,6 +367,51 @@ const tablesDBListColumnsCommand = tablesDB
   );
 
 
+const tablesDBCreateBigIntColumnCommand = tablesDB
+  .command(`create-big-int-column`)
+  .description(`Create a bigint column. Optionally, minimum and maximum values can be provided.
+`)
+  .requiredOption(`--database-id <database-id>`, `Database ID.`)
+  .requiredOption(`--table-id <table-id>`, `Table ID.`)
+  .requiredOption(`--key <key>`, `Column Key.`)
+  .requiredOption(`--required <required>`, `Is column required?`, parseBool)
+  .option(`--min <min>`, `Minimum value`, parseInteger)
+  .option(`--max <max>`, `Maximum value`, parseInteger)
+  .option(`--xdefault <xdefault>`, `Default value. Cannot be set when column is required.`, parseInteger)
+  .option(
+    `--array [value]`,
+    `Is column an array?`,
+    (value: string | undefined) =>
+      value === undefined ? true : parseBool(value),
+  )
+  .action(
+    actionRunner(
+      async ({ databaseId, tableId, key, required, min, max, xdefault, array }) =>
+        parse(await (await getTablesDBClient()).createBigIntColumn(databaseId, tableId, key, required, min, max, xdefault, array)),
+    ),
+  );
+
+
+const tablesDBUpdateBigIntColumnCommand = tablesDB
+  .command(`update-big-int-column`)
+  .description(`Update a bigint column. Changing the \`default\` value will not update already existing rows.
+`)
+  .requiredOption(`--database-id <database-id>`, `Database ID.`)
+  .requiredOption(`--table-id <table-id>`, `Table ID.`)
+  .requiredOption(`--key <key>`, `Column Key.`)
+  .requiredOption(`--required <required>`, `Is column required?`, parseBool)
+  .requiredOption(`--xdefault <xdefault>`, `Default value. Cannot be set when column is required.`, parseInteger)
+  .option(`--min <min>`, `Minimum value`, parseInteger)
+  .option(`--max <max>`, `Maximum value`, parseInteger)
+  .option(`--new-key <new-key>`, `New Column Key.`)
+  .action(
+    actionRunner(
+      async ({ databaseId, tableId, key, required, xdefault, min, max, newKey }) =>
+        parse(await (await getTablesDBClient()).updateBigIntColumn(databaseId, tableId, key, required, xdefault, min, max, newKey)),
+    ),
+  );
+
+
 const tablesDBCreateBooleanColumnCommand = tablesDB
   .command(`create-boolean-column`)
   .description(`Create a boolean column.

--- a/lib/commands/services/vcs.ts
+++ b/lib/commands/services/vcs.ts
@@ -92,14 +92,23 @@ const vcsGetRepositoryCommand = vcs
 
 const vcsListRepositoryBranchesCommand = vcs
   .command(`list-repository-branches`)
-  .description(`Get a list of all branches from a GitHub repository in your installation. This endpoint returns the names of all branches in the repository and their total count. The GitHub installation must be properly configured and have access to the requested repository for this endpoint to work.
+  .description(`Get a list of branches from a GitHub repository in your installation. This endpoint supports filtering by a search term and pagination using query strings such as \`Query.limit()\`, \`Query.offset()\`, \`Query.cursorAfter()\`, and \`Query.cursorBefore()\`. It returns branch names along with the total number of matches. The GitHub installation must be properly configured and have access to the requested repository for this endpoint to work.
 `)
   .requiredOption(`--installation-id <installation-id>`, `Installation Id`)
   .requiredOption(`--provider-repository-id <provider-repository-id>`, `Repository Id`)
+  .option(`--search <search>`, `Search term to filter your list results. Max length: 256 chars.`)
+  .option(`--queries [queries...]`, `Raw Appwrite JSON query strings (legacy). Use this for advanced queries or automation; for common filtering, sorting, and pagination prefer --where, --sort-asc, --sort-desc, --limit, and --offset. When mixed, raw --queries are sent before generated flag queries. Array of query strings generated using the Query class provided by the SDK. Learn more about queries (https://appwrite.io/docs/queries). Only supported methods are limit, offset, cursorAfter, and cursorBefore`)
+  .option(`--where <expression>`, `Filter using a simple comparison expression. Repeat for multiple filters. Supports field=value, field!=value, field>value, field>=value, field<value, and field<=value.`, (value: string, previous: string[] | undefined) => collectQueryValue(parseWhereQuery(value), previous))
+  .option(`--sort-asc <attribute>`, `Sort results by an attribute in ascending order. Repeat for multiple sort fields.`, (value: string, previous: string[] | undefined) => collectQueryValue(value, previous))
+  .option(`--sort-desc <attribute>`, `Sort results by an attribute in descending order. Repeat for multiple sort fields.`, (value: string, previous: string[] | undefined) => collectQueryValue(value, previous))
+  .option(`--limit <limit>`, `Maximum number of results to return.`, parseInteger)
+  .option(`--offset <offset>`, `Number of results to skip.`, parseInteger)
+  .option(`--cursor-after <id>`, `Return results after this cursor ID.`)
+  .option(`--cursor-before <id>`, `Return results before this cursor ID.`)
   .action(
     actionRunner(
-      async ({ installationId, providerRepositoryId }) =>
-        parse(await (await getVcsClient()).listRepositoryBranches(installationId, providerRepositoryId)),
+      async ({ installationId, providerRepositoryId, search, queries, where, sortAsc, sortDesc, cursorAfter, cursorBefore, limit, offset }) =>
+        parse(await (await getVcsClient()).listRepositoryBranches(installationId, providerRepositoryId, search, buildQueries({ queries, where, sortAsc, sortDesc, cursorAfter, cursorBefore, limit, offset }))),
     ),
   );
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -126,7 +126,10 @@ function ensureDirectoryForFile(filePath: string): void {
   }
 }
 
-function assertValidIncludePath(resource: string, includePath: unknown): string {
+function assertValidIncludePath(
+  resource: string,
+  includePath: unknown,
+): string {
   if (typeof includePath !== "string" || includePath.trim() === "") {
     throw new Error(`Config include for '${resource}' must be a file path.`);
   }
@@ -149,7 +152,9 @@ function assertValidIncludePath(resource: string, includePath: unknown): string 
   }
 
   if (_path.isAbsolute(normalizedPath)) {
-    throw new Error(`Config include '${resource}' must be a relative file path.`);
+    throw new Error(
+      `Config include '${resource}' must be a relative file path.`,
+    );
   }
 
   if (/^[a-z][a-z0-9+.-]*:/i.test(normalizedPath)) {
@@ -163,7 +168,9 @@ function assertValidIncludePath(resource: string, includePath: unknown): string 
   return normalizedPath;
 }
 
-function getConfigIncludePaths(data: Record<string, unknown>): ConfigIncludePaths {
+function getConfigIncludePaths(
+  data: Record<string, unknown>,
+): ConfigIncludePaths {
   const includes = data.includes;
   if (includes === undefined) {
     return {};
@@ -200,7 +207,10 @@ function writeJsonFile(filePath: string, data: unknown): void {
   });
 }
 
-function resolveIncludePath(configFilePath: string, includePath: string): string {
+function resolveIncludePath(
+  configFilePath: string,
+  includePath: string,
+): string {
   return _path.resolve(_path.dirname(configFilePath), includePath);
 }
 
@@ -274,10 +284,9 @@ export function getLocalConfigResourceDirname(
   return getLocalConfigResourceDirnames(filePath)[resource];
 }
 
-export function getLocalConfigResourceDirnames(filePath: string): Record<
-  "functions" | "sites",
-  string
-> {
+export function getLocalConfigResourceDirnames(
+  filePath: string,
+): Record<"functions" | "sites", string> {
   const rootData = fs.existsSync(filePath)
     ? readJsonFile<Record<string, unknown>>(filePath)
     : {};
@@ -722,7 +731,10 @@ class Local extends Config<ConfigType> {
     return _path.dirname(resolveIncludePath(this.path, includePath));
   }
 
-  resolveResourcePath(resource: ConfigResourceKey, resourcePath: string): string {
+  resolveResourcePath(
+    resource: ConfigResourceKey,
+    resourcePath: string,
+  ): string {
     if (_path.isAbsolute(resourcePath)) {
       return resourcePath;
     }

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,7 +1,7 @@
 // SDK
 export const SDK_TITLE = 'Appwrite';
 export const SDK_TITLE_LOWER = 'appwrite';
-export const SDK_VERSION = '20.1.0';
+export const SDK_VERSION = '21.0.0';
 export const SDK_NAME = 'Command Line';
 export const SDK_PLATFORM = 'console';
 export const SDK_LANGUAGE = 'cli';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "appwrite-cli",
-  "version": "20.1.0",
+  "version": "21.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "appwrite-cli",
-      "version": "20.1.0",
+      "version": "21.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@appwrite.io/console": "12.0.0",
+        "@appwrite.io/console": "12.1.0",
         "chalk": "4.1.2",
         "chokidar": "^3.6.0",
         "cli-progress": "^3.12.0",
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/@appwrite.io/console": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@appwrite.io/console/-/console-12.0.0.tgz",
-      "integrity": "sha512-lvB4z53DvUh6zPRZP7F2nbhdu5WbdqA+cJO6aCqSjZ9egqETOKOrMl6M7UtmPO6TkxM2CGsDVNf5pYDECletqg==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@appwrite.io/console/-/console-12.1.0.tgz",
+      "integrity": "sha512-pfI4UYCxEo8sGfub6UDDsQZxBu3b38x4d+SIQsZifRvKqCW+F7WRStxSQie6phw5dQaw/5SyEMEGhzURtj2MfQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "json-bigint": "1.0.0"
@@ -2137,17 +2137,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.1.tgz",
-      "integrity": "sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
+      "integrity": "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.59.1",
-        "@typescript-eslint/type-utils": "8.59.1",
-        "@typescript-eslint/utils": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1",
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/type-utils": "8.59.2",
+        "@typescript-eslint/utils": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -2160,22 +2160,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.59.1",
+        "@typescript-eslint/parser": "^8.59.2",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.1.tgz",
-      "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz",
+      "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.59.1",
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1",
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2191,14 +2191,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.1.tgz",
-      "integrity": "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz",
+      "integrity": "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.1",
-        "@typescript-eslint/types": "^8.59.1",
+        "@typescript-eslint/tsconfig-utils": "^8.59.2",
+        "@typescript-eslint/types": "^8.59.2",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2213,14 +2213,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.1.tgz",
-      "integrity": "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz",
+      "integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1"
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2231,9 +2231,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.1.tgz",
-      "integrity": "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
+      "integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2248,15 +2248,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.1.tgz",
-      "integrity": "sha512-klWPBR2ciQHS3f++ug/mVnWKPjBUo7icEL3FAO1lhAR1Z1i5NQYZ1EannMSRYcq5qCv5wNALlXr6fksRHyYl7w==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz",
+      "integrity": "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1",
-        "@typescript-eslint/utils": "8.59.1",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2",
+        "@typescript-eslint/utils": "8.59.2",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -2273,9 +2273,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz",
-      "integrity": "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz",
+      "integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2287,16 +2287,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.1.tgz",
-      "integrity": "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz",
+      "integrity": "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.59.1",
-        "@typescript-eslint/tsconfig-utils": "8.59.1",
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1",
+        "@typescript-eslint/project-service": "8.59.2",
+        "@typescript-eslint/tsconfig-utils": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2315,16 +2315,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.1.tgz",
-      "integrity": "sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.2.tgz",
+      "integrity": "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.59.1",
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1"
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2339,13 +2339,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz",
-      "integrity": "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz",
+      "integrity": "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/types": "8.59.2",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -2710,9 +2710,9 @@
       }
     },
     "node_modules/bare-url": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.2.tgz",
-      "integrity": "sha512-/9a2j4ac6ckpmAHvod/ob7x439OAHst/drc2Clnq+reRYd/ovddwcF4LfoxHyNk5AuGBnPg+HqFjmE/Zpq6v0A==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
+      "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4649,13 +4649,13 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5353,9 +5353,9 @@
       "license": "MIT"
     },
     "node_modules/node-abi": {
-      "version": "3.90.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.90.0.tgz",
-      "integrity": "sha512-pZNQT7UnYlMwMBy5N1lV5X/YLTbZM5ncytN3xL7CHEzhDN8uVe0u55yaPUJICIJjaCW8NrM5BFdqr7HLweStNA==",
+      "version": "3.91.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.91.0.tgz",
+      "integrity": "sha512-B+S7X/GS3Un6wMICtnsNjQD7oSpVBQrZftHE6GZ1Fe9/k3XOOoqbM5DZZ0GO4x3YiSCQfrM28yj1ppplwgIsfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6503,9 +6503,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "version": "7.5.14",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.14.tgz",
+      "integrity": "sha512-/7sHKgQO3JLP9ESlwTYUUftHUadOURUqq23xs1vjcnp8Vss6k0wCfzulyEtk5g91pjvnuriimGlyG7k6msrzRw==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -6811,16 +6811,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.1.tgz",
-      "integrity": "sha512-xqDcFVBmlrltH64lklOVp1wYxgJr6LVdg3NamBgH2OOQDLFdTKfIZXF5PfghrnXQKXZGTQs8tr1vL7fJvq8CTQ==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.2.tgz",
+      "integrity": "sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.59.1",
-        "@typescript-eslint/parser": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1",
-        "@typescript-eslint/utils": "8.59.1"
+        "@typescript-eslint/eslint-plugin": "8.59.2",
+        "@typescript-eslint/parser": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2",
+        "@typescript-eslint/utils": "8.59.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "homepage": "https://appwrite.io/support",
   "description": "Appwrite is an open-source self-hosted backend server that abstracts and simplifies complex and repetitive development tasks behind a very simple REST API",
-  "version": "20.1.0",
+  "version": "21.0.0",
   "license": "BSD-3-Clause",
   "main": "dist/index.cjs",
   "module": "dist/index.js",
@@ -48,10 +48,10 @@
     "mac-x64": "bun build cli.ts --compile --sourcemap=inline --target=bun-darwin-x64 --outfile build/appwrite-cli-darwin-x64",
     "mac-arm64": "bun build cli.ts --compile --sourcemap=inline --target=bun-darwin-arm64 --outfile build/appwrite-cli-darwin-arm64",
     "windows-x64": "bun build cli.ts --compile --sourcemap=inline --target=bun-windows-x64 --outfile build/appwrite-cli-win-x64.exe",
-    "windows-arm64": "esbuild cli.ts --bundle --loader:.hbs=text --platform=node --target=node18 --format=esm --external:fsevents --external:terminal-image --outfile=dist/bundle-win-arm64.mjs && pkg dist/bundle-win-arm64.mjs -t node18-win-arm64 -o build/appwrite-cli-win-arm64.exe"
+    "windows-arm64": "esbuild cli.ts --bundle --loader:.hbs=text --platform=node --target=node18 --format=esm --external:fsevents --external:terminal-image --outfile=dist/bundle-win-arm64.mjs && pkg dist/bundle-win-arm64.mjs --fallback-to-source -t node18-win-arm64 -o build/appwrite-cli-win-arm64.exe"
   },
   "dependencies": {
-    "@appwrite.io/console": "12.0.0",
+    "@appwrite.io/console": "12.1.0",
     "chalk": "4.1.2",
     "chokidar": "^3.6.0",
     "cli-progress": "^3.12.0",

--- a/scoop/appwrite.config.json
+++ b/scoop/appwrite.config.json
@@ -1,12 +1,12 @@
 {
 	"$schema": "https://raw.githubusercontent.com/ScoopInstaller/Scoop/master/schema.json",
-	"version": "20.1.0",
+	"version": "21.0.0",
 	"description": "The Appwrite CLI is a command-line application that allows you to interact with Appwrite and perform server-side tasks using your terminal.",
 	"homepage": "https://github.com/appwrite/sdk-for-cli",
 	"license": "BSD-3-Clause",
 	"architecture": {
 		"64bit": {
-			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/20.1.0/appwrite-cli-win-x64.exe",
+			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/21.0.0/appwrite-cli-win-x64.exe",
 			"bin": [
 				[
 					"appwrite-cli-win-x64.exe",
@@ -15,7 +15,7 @@
 			]
 		},
 		"arm64": {
-			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/20.1.0/appwrite-cli-win-arm64.exe",
+			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/21.0.0/appwrite-cli-win-arm64.exe",
 			"bin": [
 				[
 					"appwrite-cli-win-arm64.exe",


### PR DESCRIPTION
This PR contains updates to the SDK for version 21.0.0.

## What's Changed

* Breaking: Renamed `project update-canonical-emails`, `update-disposable-emails`, and `update-free-emails` to `update-deny-canonical-email-policy`, `update-deny-disposable-email-policy`, and `update-deny-free-email-policy`
* Breaking: Renamed `proxy update-rule-verification` to `proxy update-rule-status`
* Breaking: Renamed `--provider` to `--provider-id` on `project get-o-auth-2-provider`
* Breaking: Made `--variable-id` required on `functions create-variable` and `sites create-variable`
* Added: Introduced `bigint` create/update commands for legacy Databases attributes
* Added: Introduced `bigint` create/update commands for `TablesDB` columns
* Added: Added `--on-duplicate` flag on `tablesdb upsert-row`, `create-rows`, and `upsert-rows`
* Added: Added `--limit` flag on `vcs list-repository-branches`
* Added: Code-signed Windows release binaries (`appwrite-cli-win-x64.exe` and `appwrite-cli-win-arm64.exe`) via SignPath
* Updated: Extended key-list query filters with `key`, `resourceType`, `resourceId`, and `secret`
* Updated: Changed default `--duration` on `project create-ephemeral-key` from `1` to `600` seconds