### PR TITLE
fix(publish): quote release tag passed to SignPath

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,7 +74,7 @@ jobs:
           wait-for-completion: true
           output-artifact-directory: build-signed
           parameters: |
-            version: ${{ github.event.release.tag_name }}
+            version: "${{ github.event.release.tag_name }}"
 
       - name: Replace unsigned Windows binaries
         run: |


### PR DESCRIPTION
## Problem

The Windows-signing job on the `20.2.0-rc.1` release failed with:

```
Run signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd
Submitting the signing request to SignPath GitHub Actions connector...
Error: Invalid parameter value: 20.2.0-rc.1 - SyntaxError: Unexpected non-whitespace character after JSON at position 4 (line 1 column 5). Only valid JSON strings are allowed.
```

SignPath's GitHub Action parses each parameter VALUE as JSON. `20.2.0-rc.1` is not a valid JSON literal (numbers can't have multiple decimal points; strings must be quoted), so the action errors out at position 4 ("20.2" followed by another `.`).

Stable tags like `20.1.0` happened to *almost* parse as JSON numbers, which is why the bug only surfaces now that we cut a pre-release with a dotted/dashed suffix.

## Fix

Wrap the release tag in double quotes inside the `parameters:` block so SignPath sees `version: "20.2.0-rc.1"` — a valid JSON string.

```yaml
parameters: |
-  version: ${{ github.event.release.tag_name }}
+  version: "${{ github.event.release.tag_name }}"
```

## Test plan

- [ ] Once merged, re-run the publish workflow for the existing `20.2.0-rc.1` release and confirm the SignPath step succeeds and signed Windows binaries are produced.

## Upstream

The same fix needs to land in `appwrite/sdk-generator` (`templates/cli/.github/workflows/publish.yml`) so the next CLI regeneration doesn't re-introduce the bug. A separate PR will follow.