### PR TITLE
fix(publish): surface osslsigncode output when verify fails

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,23 +94,26 @@ jobs:
 
       - name: Verify Windows signatures
         run: |
-          set -euo pipefail
+          set -uo pipefail
 
           verify_signature() {
             local file="$1"
-            local output
-
+            local output rc
             output="$(osslsigncode verify -in "$file" 2>&1)"
+            rc=$?
+            echo "--- $file (osslsigncode exit $rc) ---"
             echo "$output"
 
-            if ! grep -Fq "Succeeded" <<< "$output"; then
-              echo "$file signature verification failed"
-              exit 1
+            if [ "$rc" -ne 0 ] || ! grep -Fq "Succeeded" <<< "$output"; then
+              echo "::error::$file signature verification failed"
+              return 1
             fi
           }
 
-          verify_signature build/appwrite-cli-win-x64.exe
-          verify_signature build/appwrite-cli-win-arm64.exe
+          final=0
+          verify_signature build/appwrite-cli-win-x64.exe || final=1
+          verify_signature build/appwrite-cli-win-arm64.exe || final=1
+          exit "$final"
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Problem

On the rerun of \`20.2.0-rc.1\` the SignPath step finally succeeded — SignPath confirmed _\"The signing request was successfully processed\"_ — but the next step, \`Verify Windows signatures\`, fails with no diagnostic. The job log goes from the verify step's \`set -uo pipefail\` setup straight to \`Process completed with exit code 1\` in ~0.3s, which is way too short for \`osslsigncode\` to have run on two ~30 MB binaries.

## Root cause

The current script:

\`\`\`bash
set -euo pipefail

verify_signature() {
  local file=\"\$1\"
  local output

  output=\"\$(osslsigncode verify -in \"\$file\" 2>&1)\"
  echo \"\$output\"
  ...
}
\`\`\`

\`output=\"\$(osslsigncode ...)\"\` captures both stdout and stderr, but under \`set -e\` the assignment **inherits the subshell's exit code**. When osslsigncode exits non-zero (e.g. CA chain not trusted by the runner — likely on the current \`test-signing\` policy), the assignment fails and \`set -e\` aborts the function before \`echo \"\$output\"\` runs. The captured output is discarded and we get a bare \`exit 1\`.

## Fix

- Drop \`set -e\` for this block (we already handle errors explicitly).
- Capture osslsigncode's exit code separately and echo the output before deciding pass/fail.
- Aggregate per-file results so both binaries are reported even if the first one fails.
- Emit \`::error::\` annotations so failures land in the Actions UI.

## Test plan

- [ ] Merge and re-run the existing \`20.2.0-rc.1\` publish workflow (\`gh run rerun 25651791691 --repo appwrite/sdk-for-cli --failed\`).
- [ ] Confirm the \`Verify Windows signatures\` step now prints the actual osslsigncode output regardless of exit code.

## Upstream

Companion PR will land on \`appwrite/sdk-generator\` (\`templates/cli/.github/workflows/publish.yml\`) so the next CLI regeneration carries the same fix.