### PR TITLE
fix(publish): bump actions/upload-artifact to v4.6.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload unsigned Windows binaries
         id: upload-windows-unsigned
-        uses: actions/upload-artifact@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: windows-unsigned
           path: |


### PR DESCRIPTION
Re-release of 21.0.0 with the publish workflow fix from `appwrite/sdk-generator` 1.29.4.

The previous release pipeline failed on the unsigned-windows upload step (`actions/upload-artifact@v4.2.4` is deprecated). This bumps the pinned SHA to v4.6.2.

## Changes
- `.github/workflows/publish.yml`: `actions/upload-artifact` SHA pin `0400d5f` (v4.2.4) → `ea165f8` (v4.6.2)

No version bump or changelog changes — same 21.0.0 release.