### PR TITLE
fix(publish): verify-windows-signatures resilient under errexit

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,8 +99,8 @@ jobs:
           verify_signature() {
             local file="$1"
             local output rc
-            output="$(osslsigncode verify -in "$file" 2>&1)"
-            rc=$?
+            rc=0
+            output="$(osslsigncode verify -in "$file" 2>&1)" || rc=$?
             echo "--- $file (osslsigncode exit $rc) ---"
             echo "$output"
 


### PR DESCRIPTION
Re-release of 21.0.0 with the verify-signature fix from `appwrite/sdk-generator` 1.29.5 ([PR #1542](https://github.com/appwrite/sdk-generator/pull/1542)).

Previous pipeline failed at the "Verify Windows signatures" step because the command substitution `output=$(osslsigncode verify ...)` propagated osslsigncode's non-zero exit under GHA's default `bash -e`, killing the script before the warning path could run.

## Changes
- `.github/workflows/publish.yml`: use `|| rc=$?` so the verify command's exit code is captured without tripping errexit

No version bump or changelog changes — same 21.0.0 release.