### PR TITLE
feat: SDK update for version 22.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 22.1.1
+
+* Added: Support for logging into staging Cloud environments (`stage.cloud.appwrite.io`)
+* Updated: Compiled binaries now built with `--minify` instead of inline sourcemaps
+
 ## 22.1.0
 
 * Fixed: `organization get-invoice-download` and `get-invoice-view` now save the invoice to disk via `--destination`

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Once the installation is complete, you can verify the install using
 
 ```sh
 $ appwrite -v
-22.1.0
+22.1.1
 ```
 
 ### Install using prebuilt binaries
@@ -83,7 +83,7 @@ $ scoop install https://raw.githubusercontent.com/appwrite/sdk-for-cli/master/sc
 Once the installation completes, you can verify your install using
 ```
 $ appwrite -v
-22.1.0
+22.1.1
 ```
 
 ## Getting Started 

--- a/install.ps1
+++ b/install.ps1
@@ -13,8 +13,8 @@
 # You can use "View source" of this page to see the full script.
 
 # REPO
-$GITHUB_x64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/22.1.0/appwrite-cli-win-x64.exe"
-$GITHUB_arm64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/22.1.0/appwrite-cli-win-arm64.exe"
+$GITHUB_x64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/22.1.1/appwrite-cli-win-x64.exe"
+$GITHUB_arm64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/22.1.1/appwrite-cli-win-arm64.exe"
 
 $APPWRITE_BINARY_NAME = "appwrite.exe"
 

--- a/install.sh
+++ b/install.sh
@@ -120,7 +120,7 @@ verifyMacOSCodeSignature() {
 downloadBinary() {
     echo "[2/5] Downloading executable for $OS ($ARCH) ..."
 
-    GITHUB_LATEST_VERSION="22.1.0"
+    GITHUB_LATEST_VERSION="22.1.1"
     GITHUB_FILE="appwrite-cli-${OS}-${ARCH}"
     GITHUB_URL="https://github.com/$GITHUB_REPOSITORY_NAME/releases/download/$GITHUB_LATEST_VERSION/$GITHUB_FILE"
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,7 +1,7 @@
 // SDK
 export const SDK_TITLE = 'Appwrite';
 export const SDK_TITLE_LOWER = 'appwrite';
-export const SDK_VERSION = '22.1.0';
+export const SDK_VERSION = '22.1.1';
 export const SDK_NAME = 'Command Line';
 export const SDK_PLATFORM = 'console';
 export const SDK_LANGUAGE = 'cli';

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -364,6 +364,7 @@ const getHomebrewLatestVersion = async (
 
 // TODO: Derive this list from the regions in the API spec.
 const CLOUD_REGION_CODES = new Set(["fra", "nyc", "syd", "sfo", "sgp", "tor"]);
+const CLOUD_LOGIN_ENVIRONMENTS = new Set(["stage"]);
 
 export const isCloudHostname = (hostname: string): boolean => {
   if (hostname === "cloud.appwrite.io") {
@@ -389,11 +390,16 @@ export const isRegionalCloudEndpoint = (endpoint: string): boolean => {
 export const isLocalhostHostname = (hostname: string): boolean =>
   hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
 
+const isCloudEnvironmentHostname = (hostname: string): boolean =>
+  hostname.endsWith(".cloud.appwrite.io") &&
+  CLOUD_LOGIN_ENVIRONMENTS.has(hostname.split(".")[0]);
+
 export const isCloudLoginEndpoint = (endpoint: string): boolean => {
   try {
     const hostname = new URL(endpoint).hostname;
     return (
       isCloudHostname(hostname) ||
+      isCloudEnvironmentHostname(hostname) ||
       (isFlagEnabled("devCloudLogin") && isLocalhostHostname(hostname))
     );
   } catch (_error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appwrite-cli",
-  "version": "22.1.0",
+  "version": "22.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "appwrite-cli",
-      "version": "22.1.0",
+      "version": "22.1.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@appwrite.io/console": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "homepage": "https://appwrite.io/support",
   "description": "Appwrite is an open-source self-hosted backend server that abstracts and simplifies complex and repetitive development tasks behind a very simple REST API",
-  "version": "22.1.0",
+  "version": "22.1.1",
   "license": "BSD-3-Clause",
   "main": "dist/index.cjs",
   "module": "dist/index.js",
@@ -43,12 +43,12 @@
     "generate": "tsx scripts/generate-commands.ts",
     "prepublishOnly": "npm run build",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "linux-x64": "bun build cli.ts --compile --sourcemap=inline --target=bun-linux-x64 --outfile build/appwrite-cli-linux-x64",
-    "linux-arm64": "bun build cli.ts --compile --sourcemap=inline --target=bun-linux-arm64 --outfile build/appwrite-cli-linux-arm64",
-    "mac-x64": "bun build cli.ts --compile --sourcemap=inline --target=bun-darwin-x64 --outfile build/appwrite-cli-darwin-x64",
-    "mac-arm64": "bun build cli.ts --compile --sourcemap=inline --target=bun-darwin-arm64 --outfile build/appwrite-cli-darwin-arm64",
-    "windows-x64": "bun build cli.ts --compile --sourcemap=inline --target=bun-windows-x64 --outfile build/appwrite-cli-win-x64.exe",
-    "windows-arm64": "bun build cli.ts --compile --sourcemap=inline --target=bun-windows-arm64 --outfile build/appwrite-cli-win-arm64.exe"
+    "linux-x64": "bun build cli.ts --compile --minify --target=bun-linux-x64 --outfile build/appwrite-cli-linux-x64",
+    "linux-arm64": "bun build cli.ts --compile --minify --target=bun-linux-arm64 --outfile build/appwrite-cli-linux-arm64",
+    "mac-x64": "bun build cli.ts --compile --minify --target=bun-darwin-x64 --outfile build/appwrite-cli-darwin-x64",
+    "mac-arm64": "bun build cli.ts --compile --minify --target=bun-darwin-arm64 --outfile build/appwrite-cli-darwin-arm64",
+    "windows-x64": "bun build cli.ts --compile --minify --target=bun-windows-x64 --outfile build/appwrite-cli-win-x64.exe",
+    "windows-arm64": "bun build cli.ts --compile --minify --target=bun-windows-arm64 --outfile build/appwrite-cli-win-arm64.exe"
   },
   "dependencies": {
     "@appwrite.io/console": "^15.0.0",

--- a/scoop/appwrite.config.json
+++ b/scoop/appwrite.config.json
@@ -1,12 +1,12 @@
 {
 	"$schema": "https://raw.githubusercontent.com/ScoopInstaller/Scoop/master/schema.json",
-	"version": "22.1.0",
+	"version": "22.1.1",
 	"description": "The Appwrite CLI is a command-line application that allows you to interact with Appwrite and perform server-side tasks using your terminal.",
 	"homepage": "https://github.com/appwrite/sdk-for-cli",
 	"license": "BSD-3-Clause",
 	"architecture": {
 		"64bit": {
-			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/22.1.0/appwrite-cli-win-x64.exe",
+			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/22.1.1/appwrite-cli-win-x64.exe",
 			"bin": [
 				[
 					"appwrite-cli-win-x64.exe",
@@ -15,7 +15,7 @@
 			]
 		},
 		"arm64": {
-			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/22.1.0/appwrite-cli-win-arm64.exe",
+			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/22.1.1/appwrite-cli-win-arm64.exe",
 			"bin": [
 				[
 					"appwrite-cli-win-arm64.exe",


### PR DESCRIPTION
This PR contains updates to the SDK for version 22.1.1.

## What's Changed

* Added: Support for logging into staging Cloud environments (`stage.cloud.appwrite.io`)
* Updated: Compiled binaries now built with `--minify` instead of inline sourcemaps