### PR TITLE
feat: SDK update for version 22.2.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,9 +43,21 @@ jobs:
           sudo make
           sudo make install
 
-      - name: Install dependencies and build for Linux and Windows
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Fetch keyring native bindings for all targets
         run: |
-          bun install --frozen-lockfile
+          version="$(bun -e 'console.log(require("@napi-rs/keyring/package.json").version)')"
+          for triple in darwin-arm64 darwin-x64 linux-x64-gnu linux-arm64-gnu win32-x64-msvc win32-arm64-msvc; do
+            dir="node_modules/@napi-rs/keyring-$triple"
+            [ -d "$dir" ] && continue
+            mkdir -p "$dir"
+            curl -fsSL "https://registry.npmjs.org/@napi-rs/keyring-$triple/-/keyring-$triple-$version.tgz" | tar -xz -C "$dir" --strip-components=1
+          done
+
+      - name: Build for Linux and Windows
+        run: |
           bun run linux-x64
           bun run linux-arm64
           bun run mac-x64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 22.2.2
+
+* Fixed: Release binaries now embed `@napi-rs/keyring` native bindings for all targets
+
 ## 22.2.1
 
 * Fixed: Compiled binaries no longer crash from `@napi-rs/keyring` native bindings

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Once the installation is complete, you can verify the install using
 
 ```sh
 $ appwrite -v
-22.2.1
+22.2.2
 ```
 
 ### Install using prebuilt binaries
@@ -83,7 +83,7 @@ $ scoop install https://raw.githubusercontent.com/appwrite/sdk-for-cli/master/sc
 Once the installation completes, you can verify your install using
 ```
 $ appwrite -v
-22.2.1
+22.2.2
 ```
 
 ## Getting Started 

--- a/install.ps1
+++ b/install.ps1
@@ -13,8 +13,8 @@
 # You can use "View source" of this page to see the full script.
 
 # REPO
-$GITHUB_x64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/22.2.1/appwrite-cli-win-x64.exe"
-$GITHUB_arm64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/22.2.1/appwrite-cli-win-arm64.exe"
+$GITHUB_x64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/22.2.2/appwrite-cli-win-x64.exe"
+$GITHUB_arm64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/22.2.2/appwrite-cli-win-arm64.exe"
 
 $APPWRITE_BINARY_NAME = "appwrite.exe"
 

--- a/install.sh
+++ b/install.sh
@@ -120,7 +120,7 @@ verifyMacOSCodeSignature() {
 downloadBinary() {
     echo "[2/5] Downloading executable for $OS ($ARCH) ..."
 
-    GITHUB_LATEST_VERSION="22.2.1"
+    GITHUB_LATEST_VERSION="22.2.2"
     GITHUB_FILE="appwrite-cli-${OS}-${ARCH}"
     GITHUB_URL="https://github.com/$GITHUB_REPOSITORY_NAME/releases/download/$GITHUB_LATEST_VERSION/$GITHUB_FILE"
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,7 +1,7 @@
 // SDK
 export const SDK_TITLE = 'Appwrite';
 export const SDK_TITLE_LOWER = 'appwrite';
-export const SDK_VERSION = '22.2.1';
+export const SDK_VERSION = '22.2.2';
 export const SDK_NAME = 'Command Line';
 export const SDK_PLATFORM = 'console';
 export const SDK_LANGUAGE = 'cli';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appwrite-cli",
-  "version": "22.2.1",
+  "version": "22.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "appwrite-cli",
-      "version": "22.2.1",
+      "version": "22.2.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@appwrite.io/console": "^15.1.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "homepage": "https://appwrite.io/support",
   "description": "Appwrite is an open-source self-hosted backend server that abstracts and simplifies complex and repetitive development tasks behind a very simple REST API",
-  "version": "22.2.1",
+  "version": "22.2.2",
   "license": "BSD-3-Clause",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/scoop/appwrite.config.json
+++ b/scoop/appwrite.config.json
@@ -1,12 +1,12 @@
 {
 	"$schema": "https://raw.githubusercontent.com/ScoopInstaller/Scoop/master/schema.json",
-	"version": "22.2.1",
+	"version": "22.2.2",
 	"description": "The Appwrite CLI is a command-line application that allows you to interact with Appwrite and perform server-side tasks using your terminal.",
 	"homepage": "https://github.com/appwrite/sdk-for-cli",
 	"license": "BSD-3-Clause",
 	"architecture": {
 		"64bit": {
-			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/22.2.1/appwrite-cli-win-x64.exe",
+			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/22.2.2/appwrite-cli-win-x64.exe",
 			"bin": [
 				[
 					"appwrite-cli-win-x64.exe",
@@ -15,7 +15,7 @@
 			]
 		},
 		"arm64": {
-			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/22.2.1/appwrite-cli-win-arm64.exe",
+			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/22.2.2/appwrite-cli-win-arm64.exe",
 			"bin": [
 				[
 					"appwrite-cli-win-arm64.exe",


### PR DESCRIPTION
This PR contains updates to the SDK for version 22.2.2.

## What's Changed

* Fixed: Release binaries now embed `@napi-rs/keyring` native bindings for all targets