### PR TITLE
feat: SDK update for version 22.5.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -142,6 +142,14 @@ jobs:
             echo "tag=latest" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Audit npm dependencies
+        run: |
+          # CLI builds with Bun, but npm audit reads package-lock.json.
+          # update-lockfiles.sh updates both lockfiles; this catches npm lock drift.
+          npm install --package-lock-only --ignore-scripts
+          git diff --exit-code package-lock.json
+          npm audit --audit-level=high --omit=dev
+
       - name: Publish
         run: npm publish --provenance --access public --tag ${{ steps.release_tag.outputs.tag }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Change Log
 
+## 22.5.0
+
+* Updated: `tablesdb create` now takes `--specification` instead of `--dedicated-database-id`
+* Updated: Removed `health get-queue-logs` command
+* Added: `notifications` command group for console notifications
+* Added: `organization get`, `update`, and `delete` commands
+* Added: `organization list-memberships`, `create-membership`, `get-membership`, `update-membership`, and `delete-membership` commands
+* Added: `tablesdb list-migrations`, `create-migration`, `get-migration`, and `delete-migration` commands for dedicated database migrations
+* Added: `oauth2 create-par`, `list-organizations`, and `list-projects` commands
+* Added: `--request-_uri` option on `oauth2 authorize`; client ID, redirect URI, and response type are now optional
+* Added: `projects list-addons`, `get-addon`, `delete-addon`, `confirm-addon-payment`, and `get-addon-price` commands
+* Added: `create-premium-geo-db-addon` command on `projects` and `organizations`
+* Added: `account list-logs`, `teams list-logs`, and `users list-logs` commands
+* Added: `health get-geo` and `get-geo-premium` commands
+* Added: `--new-specification` option on `backups create-restoration`
+* Added: `--prompt` and `--max-age` options on `project update-o-auth-2-oidc`
+* Fixed: Project config validation now sends the `X-Appwrite-Project` header, fixing 401 errors for guest sessions
+* Fixed: Update check now reads the latest version from the Homebrew tap instead of stale local metadata
+
 ## 22.4.0
 
 * Updated: Removed pre-release activity log commands `list-logs`, `list-collection-logs`, `list-document-logs`, `list-table-logs`, `list-row-logs`, `list-message-logs`, `list-provider-logs`, `list-subscriber-logs`, and `list-topic-logs`

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Once the installation is complete, you can verify the install using
 
 ```sh
 $ appwrite -v
-22.4.0
+22.5.0
 ```
 
 ### Install using prebuilt binaries
@@ -83,7 +83,7 @@ $ scoop install https://raw.githubusercontent.com/appwrite/sdk-for-cli/master/sc
 Once the installation completes, you can verify your install using
 ```
 $ appwrite -v
-22.4.0
+22.5.0
 ```
 
 ## Getting Started 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "appwrite-cli",
       "dependencies": {
-        "@appwrite.io/console": "^15.1.1",
+        "@appwrite.io/console": "15.3.0-rc.1",
         "@napi-rs/keyring": "^1.3.0",
         "chalk": "4.1.2",
         "chokidar": "^3.6.0",
@@ -52,7 +52,7 @@
     "tmp": "^0.2.6",
   },
   "packages": {
-    "@appwrite.io/console": ["@appwrite.io/console@15.1.1", "", { "dependencies": { "json-bigint": "1.0.0" } }, "sha512-W4t9xNuHoNUYGypcZtgPaHvuS/AFjSdDDleeNQl3cWMiOrS9wasVyIwygAHeQjis9evwPC4WUbfpx8WWYXijDg=="],
+    "@appwrite.io/console": ["@appwrite.io/console@15.3.0-rc.1", "", { "dependencies": { "json-bigint": "1.0.0" } }, "sha512-OvjwB0qEzJPFxCc6Hlg1AIU92SRBTjQv+xuXJ80wT7oaxpR4WwULj6qYrQrRe3jzK8OatO+NytZ8OQIgg+nyxg=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
@@ -764,11 +764,7 @@
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
-    "@eslint/config-array/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
-
     "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
-
-    "@eslint/eslintrc/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "@isaacs/fs-minipass/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
@@ -872,8 +868,6 @@
 
     "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
-    "espree/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
-
     "external-editor/chardet": ["chardet@0.4.2", "", {}, "sha512-j/Toj7f1z98Hh2cYo2BVr85EpIRWqUi7rtRSGxh/cqUjqrnJe9l9UE7IUGd2vQ2p+kSHLkSzObQPZPLUC6TQwg=="],
 
     "external-editor/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
@@ -928,10 +922,6 @@
 
     "xml2js/xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
 
-    "@eslint/config-array/minimatch/brace-expansion": ["brace-expansion@1.1.15", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg=="],
-
-    "@eslint/eslintrc/minimatch/brace-expansion": ["brace-expansion@1.1.15", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg=="],
-
     "@jimp/custom/@jimp/core/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
 
     "@jimp/custom/@jimp/core/file-type": ["file-type@9.0.0", "", {}, "sha512-Qe/5NJrgIOlwijpq3B7BEpzPFcgzggOTagZmkXQY4LA6bsXKTUstK7Wp12lEJ/mLKTpvIZxmIuRcLYWT6ov9lw=="],
@@ -976,8 +966,6 @@
 
     "cli-table3/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
-    "cli-table3/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
-
     "filelist/minimatch/brace-expansion": ["brace-expansion@2.1.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA=="],
 
     "inquirer-search-list/chalk/ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
@@ -1002,8 +990,6 @@
 
     "inquirer/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
-    "inquirer/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
-
     "log-update/cli-cursor/restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
     "log-update/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
@@ -1016,17 +1002,9 @@
 
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
-    "wrap-ansi/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
-
-    "@eslint/config-array/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
-
-    "@eslint/eslintrc/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
-
     "@jimp/custom/@jimp/core/pixelmatch/pngjs": ["pngjs@3.4.0", "", {}, "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
-
-    "filelist/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "inquirer-search-list/chalk/ansi-styles/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
 

--- a/cli.ts
+++ b/cli.ts
@@ -44,6 +44,7 @@ import { health } from './lib/commands/services/health.js';
 import { locale } from './lib/commands/services/locale.js';
 import { messaging } from './lib/commands/services/messaging.js';
 import { migrations } from './lib/commands/services/migrations.js';
+import { notifications } from './lib/commands/services/notifications.js';
 import { oauth2 } from './lib/commands/services/oauth-2.js';
 import { organization } from './lib/commands/services/organization.js';
 import { organizations } from './lib/commands/services/organizations.js';
@@ -217,6 +218,7 @@ if (process.argv.includes('-v') || process.argv.includes('--version')) {
             .addCommand(locale)
             .addCommand(messaging)
             .addCommand(migrations)
+            .addCommand(notifications)
             .addCommand(oauth2)
             .addCommand(organization)
             .addCommand(organizations)

--- a/docs/examples/account/list-logs.md
+++ b/docs/examples/account/list-logs.md
@@ -1,0 +1,4 @@
+```bash
+appwrite account list-logs \
+    --limit 25
+```

--- a/docs/examples/health/get-geo-premium.md
+++ b/docs/examples/health/get-geo-premium.md
@@ -1,0 +1,3 @@
+```bash
+appwrite health get-geo-premium
+```

--- a/docs/examples/health/get-geo.md
+++ b/docs/examples/health/get-geo.md
@@ -1,0 +1,3 @@
+```bash
+appwrite health get-geo
+```

--- a/docs/examples/health/get-queue-logs.md
+++ b/docs/examples/health/get-queue-logs.md
@@ -1,3 +1,0 @@
-```bash
-appwrite health get-queue-logs
-```

--- a/docs/examples/notifications/list.md
+++ b/docs/examples/notifications/list.md
@@ -1,0 +1,4 @@
+```bash
+appwrite notifications list \
+    --limit 25
+```

--- a/docs/examples/notifications/update.md
+++ b/docs/examples/notifications/update.md
@@ -1,0 +1,5 @@
+```bash
+appwrite notifications update \
+    --notification-id <NOTIFICATION_ID> \
+    --read false
+```

--- a/docs/examples/oauth2/authorize.md
+++ b/docs/examples/oauth2/authorize.md
@@ -1,6 +1,3 @@
 ```bash
-appwrite oauth-2 authorize \
-    --client-_id <CLIENT_ID> \
-    --redirect-_uri https://example.com \
-    --response-_type code
+appwrite oauth-2 authorize
 ```

--- a/docs/examples/oauth2/create-par.md
+++ b/docs/examples/oauth2/create-par.md
@@ -1,0 +1,7 @@
+```bash
+appwrite oauth-2 create-par \
+    --client-_id <CLIENT_ID> \
+    --redirect-_uri https://example.com \
+    --response-_type code \
+    --scope <SCOPE>
+```

--- a/docs/examples/oauth2/list-organizations.md
+++ b/docs/examples/oauth2/list-organizations.md
@@ -1,0 +1,3 @@
+```bash
+appwrite oauth-2 list-organizations
+```

--- a/docs/examples/oauth2/list-projects.md
+++ b/docs/examples/oauth2/list-projects.md
@@ -1,0 +1,3 @@
+```bash
+appwrite oauth-2 list-projects
+```

--- a/docs/examples/organization/create-membership.md
+++ b/docs/examples/organization/create-membership.md
@@ -1,0 +1,4 @@
+```bash
+appwrite organization create-membership \
+    --roles one two three
+```

--- a/docs/examples/organization/delete-membership.md
+++ b/docs/examples/organization/delete-membership.md
@@ -1,0 +1,4 @@
+```bash
+appwrite organization delete-membership \
+    --membership-id <MEMBERSHIP_ID>
+```

--- a/docs/examples/organization/delete.md
+++ b/docs/examples/organization/delete.md
@@ -1,0 +1,3 @@
+```bash
+appwrite organization delete
+```

--- a/docs/examples/organization/get-membership.md
+++ b/docs/examples/organization/get-membership.md
@@ -1,0 +1,4 @@
+```bash
+appwrite organization get-membership \
+    --membership-id <MEMBERSHIP_ID>
+```

--- a/docs/examples/organization/get.md
+++ b/docs/examples/organization/get.md
@@ -1,0 +1,3 @@
+```bash
+appwrite organization get
+```

--- a/docs/examples/organization/list-memberships.md
+++ b/docs/examples/organization/list-memberships.md
@@ -1,0 +1,4 @@
+```bash
+appwrite organization list-memberships \
+    --limit 25
+```

--- a/docs/examples/organization/update-membership.md
+++ b/docs/examples/organization/update-membership.md
@@ -1,0 +1,5 @@
+```bash
+appwrite organization update-membership \
+    --membership-id <MEMBERSHIP_ID> \
+    --roles one two three
+```

--- a/docs/examples/organization/update.md
+++ b/docs/examples/organization/update.md
@@ -1,0 +1,4 @@
+```bash
+appwrite organization update \
+    --name <NAME>
+```

--- a/docs/examples/organizations/create-premium-geo-db-addon.md
+++ b/docs/examples/organizations/create-premium-geo-db-addon.md
@@ -1,0 +1,4 @@
+```bash
+appwrite organizations create-premium-geo-db-addon \
+    --organization-id <ORGANIZATION_ID>
+```

--- a/docs/examples/projects/confirm-addon-payment.md
+++ b/docs/examples/projects/confirm-addon-payment.md
@@ -1,0 +1,5 @@
+```bash
+appwrite projects confirm-addon-payment \
+    --project-id <PROJECT_ID> \
+    --addon-id <ADDON_ID>
+```

--- a/docs/examples/projects/create-premium-geo-db-addon.md
+++ b/docs/examples/projects/create-premium-geo-db-addon.md
@@ -1,0 +1,4 @@
+```bash
+appwrite projects create-premium-geo-db-addon \
+    --project-id <PROJECT_ID>
+```

--- a/docs/examples/projects/delete-addon.md
+++ b/docs/examples/projects/delete-addon.md
@@ -1,0 +1,5 @@
+```bash
+appwrite projects delete-addon \
+    --project-id <PROJECT_ID> \
+    --addon-id <ADDON_ID>
+```

--- a/docs/examples/projects/get-addon-price.md
+++ b/docs/examples/projects/get-addon-price.md
@@ -1,0 +1,5 @@
+```bash
+appwrite projects get-addon-price \
+    --project-id <PROJECT_ID> \
+    --addon baa
+```

--- a/docs/examples/projects/get-addon.md
+++ b/docs/examples/projects/get-addon.md
@@ -1,0 +1,5 @@
+```bash
+appwrite projects get-addon \
+    --project-id <PROJECT_ID> \
+    --addon-id <ADDON_ID>
+```

--- a/docs/examples/projects/list-addons.md
+++ b/docs/examples/projects/list-addons.md
@@ -1,0 +1,4 @@
+```bash
+appwrite projects list-addons \
+    --project-id <PROJECT_ID>
+```

--- a/docs/examples/tablesdb/create-migration.md
+++ b/docs/examples/tablesdb/create-migration.md
@@ -1,0 +1,5 @@
+```bash
+appwrite tables-db create-migration \
+    --database-id <DATABASE_ID> \
+    --specification s-1vcpu-1gb
+```

--- a/docs/examples/tablesdb/delete-migration.md
+++ b/docs/examples/tablesdb/delete-migration.md
@@ -1,0 +1,5 @@
+```bash
+appwrite tables-db delete-migration \
+    --database-id <DATABASE_ID> \
+    --migration-id <MIGRATION_ID>
+```

--- a/docs/examples/tablesdb/get-migration.md
+++ b/docs/examples/tablesdb/get-migration.md
@@ -1,0 +1,5 @@
+```bash
+appwrite tables-db get-migration \
+    --database-id <DATABASE_ID> \
+    --migration-id <MIGRATION_ID>
+```

--- a/docs/examples/tablesdb/list-migrations.md
+++ b/docs/examples/tablesdb/list-migrations.md
@@ -1,0 +1,4 @@
+```bash
+appwrite tables-db list-migrations \
+    --database-id <DATABASE_ID>
+```

--- a/docs/examples/teams/list-logs.md
+++ b/docs/examples/teams/list-logs.md
@@ -1,0 +1,5 @@
+```bash
+appwrite teams list-logs \
+    --team-id <TEAM_ID> \
+    --limit 25
+```

--- a/docs/examples/users/list-logs.md
+++ b/docs/examples/users/list-logs.md
@@ -1,0 +1,5 @@
+```bash
+appwrite users list-logs \
+    --user-id <USER_ID> \
+    --limit 25
+```

--- a/install.ps1
+++ b/install.ps1
@@ -13,8 +13,8 @@
 # You can use "View source" of this page to see the full script.
 
 # REPO
-$GITHUB_x64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/22.4.0/appwrite-cli-win-x64.exe"
-$GITHUB_arm64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/22.4.0/appwrite-cli-win-arm64.exe"
+$GITHUB_x64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/22.5.0/appwrite-cli-win-x64.exe"
+$GITHUB_arm64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/22.5.0/appwrite-cli-win-arm64.exe"
 
 $APPWRITE_BINARY_NAME = "appwrite.exe"
 

--- a/install.sh
+++ b/install.sh
@@ -120,7 +120,7 @@ verifyMacOSCodeSignature() {
 downloadBinary() {
     echo "[2/5] Downloading executable for $OS ($ARCH) ..."
 
-    GITHUB_LATEST_VERSION="22.4.0"
+    GITHUB_LATEST_VERSION="22.5.0"
     GITHUB_FILE="appwrite-cli-${OS}-${ARCH}"
     GITHUB_URL="https://github.com/$GITHUB_REPOSITORY_NAME/releases/download/$GITHUB_LATEST_VERSION/$GITHUB_FILE"
 

--- a/lib/commands/services/account.ts
+++ b/lib/commands/services/account.ts
@@ -203,6 +203,26 @@ const accountDeleteKeyCommand = account
   );
 
 
+const accountListLogsCommand = account
+  .command(`list-logs`)
+  .description(`Get the list of latest security activity logs for the currently logged in user. Each log returns user IP address, location and date and time of log.`)
+  .option(`--queries [queries...]`, `Raw Appwrite JSON query strings (legacy). Use this for advanced queries or automation; for common pagination prefer --limit and --offset. When mixed, raw --queries are sent before generated flag queries. Array of query strings generated using the Query class provided by the SDK. Learn more about queries (https://appwrite.io/docs/queries). Only supported methods are limit and offset`)
+  .option(
+    `--total [value]`,
+    `When set to false, the total count returned will be 0 and will not be calculated.`,
+    (value: string | undefined) =>
+      value === undefined ? true : parseBool(value),
+  )
+  .option(`--limit <limit>`, `Maximum number of results to return.`, parseInteger)
+  .option(`--offset <offset>`, `Number of results to skip.`, parseInteger)
+  .action(
+    actionRunner(
+      async ({ queries, total, limit, offset }) =>
+        parse(await (await getAccountClient()).listLogs(buildQueries({ queries, limit, offset }), total)),
+    ),
+  );
+
+
 const accountUpdateMFACommand = account
   .command(`update-mfa`)
   .description(`Enable or disable MFA on an account.`)

--- a/lib/commands/services/backups.ts
+++ b/lib/commands/services/backups.ts
@@ -179,15 +179,19 @@ const backupsDeletePolicyCommand = backups
 
 const backupsCreateRestorationCommand = backups
   .command(`create-restoration`)
-  .description(`Create and trigger a new restoration for a backup on a project.`)
+  .description(`Create and trigger a new restoration for a backup on a project.
+
+When restoring a DocumentsDB or VectorsDB database to a new resource, pass \`newSpecification\` to provision the restored database on a different specification than the archived one (for example, restoring onto a larger or smaller dedicated database). Use \`serverless\` to restore onto the shared pool, or a dedicated specification slug to restore onto a dedicated database of that size. The specification must be permitted by the organization's plan. \`newSpecification\` is not supported for legacy/TablesDB databases or for bucket restores.
+`)
   .requiredOption(`--archive-id <archive-id>`, `Backup archive ID to restore`)
   .requiredOption(`--services [services...]`, `Array of services to restore`)
   .option(`--new-resource-id <new-resource-id>`, `Unique Id. Choose a custom ID or generate a random ID with \`ID.unique()\`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can't start with a special char. Max length is 36 chars.`)
   .option(`--new-resource-name <new-resource-name>`, `Database name. Max length: 128 chars.`)
+  .option(`--new-specification <new-specification>`, `Specification to provision the restored database on, when restoring a DocumentsDB or VectorsDB database to a new resource. Defaults to the archived database's specification. Use \`serverless\` for the shared pool or a dedicated specification slug.`)
   .action(
     actionRunner(
-      async ({ archiveId, services, newResourceId, newResourceName }) =>
-        parse(await (await getBackupsClient()).createRestoration(archiveId, services, newResourceId, newResourceName)),
+      async ({ archiveId, services, newResourceId, newResourceName, newSpecification }) =>
+        parse(await (await getBackupsClient()).createRestoration(archiveId, services, newResourceId, newResourceName, newSpecification)),
     ),
   );
 

--- a/lib/commands/services/health.ts
+++ b/lib/commands/services/health.ts
@@ -78,6 +78,27 @@ const healthGetDBCommand = health
   );
 
 
+const healthGetGeoCommand = health
+  .command(`get-geo`)
+  .description(`Check the Appwrite geo service is up and connection is successful.`)
+  .action(
+    actionRunner(
+      async () => parse(await (await getHealthClient()).getGeo()),
+    ),
+  );
+
+
+const healthGetGeoPremiumCommand = health
+  .command(`get-geo-premium`)
+  .description(`Get the health status of the premium geo service. This endpoint probes the internal \`appwrite-geo-premium\` service used for premium IP-to-location lookups (organizations or projects on the premium geo DB addon) and returns a \`pass\` status when reachable.
+`)
+  .action(
+    actionRunner(
+      async () => parse(await (await getHealthClient()).getGeoPremium()),
+    ),
+  );
+
+
 const healthGetPubSubCommand = health
   .command(`get-pub-sub`)
   .description(`Check the Appwrite pub-sub servers are up and connection is successful.`)
@@ -172,18 +193,6 @@ const healthGetQueueFunctionsCommand = health
     actionRunner(
       async ({ threshold }) =>
         parse(await (await getHealthClient()).getQueueFunctions(threshold)),
-    ),
-  );
-
-
-const healthGetQueueLogsCommand = health
-  .command(`get-queue-logs`)
-  .description(`Get the number of logs that are waiting to be processed in the Appwrite internal queue server.`)
-  .option(`--threshold <threshold>`, `Queue size threshold. When hit (equal or higher), endpoint returns server error. Default value is 5000.`, parseInteger)
-  .action(
-    actionRunner(
-      async ({ threshold }) =>
-        parse(await (await getHealthClient()).getQueueLogs(threshold)),
     ),
   );
 

--- a/lib/commands/services/notifications.ts
+++ b/lib/commands/services/notifications.ts
@@ -1,0 +1,69 @@
+import { Command } from "commander";
+import {
+  buildQueries,
+  collectQueryValue,
+  parseDeprecatedWhereQuery,
+  parseFilterQuery,
+} from "../utils/query.js";
+import { sdkForProject } from "../../sdks.js";
+import {
+  actionRunner,
+  commandDescriptions,
+  success,
+  parse,
+  parseBool,
+  parseInteger,
+} from "../../parser.js";
+import { Notifications } from "@appwrite.io/console";
+
+let notificationsClient: Notifications | null = null;
+
+const getNotificationsClient = async (): Promise<Notifications> => {
+  if (!notificationsClient) {
+    const sdkClient = await sdkForProject();
+    notificationsClient = new Notifications(sdkClient);
+  }
+  return notificationsClient;
+};
+
+export const notifications = new Command("notifications")
+  .description(commandDescriptions["notifications"] ?? "")
+  .configureHelp({
+    helpWidth: process.stdout.columns || 80,
+  });
+
+const notificationsListCommand = notifications
+  .command(`list`)
+  .description(`Get the list of notifications for the currently logged in console user. Use queries to filter the results by attributes such as read status, view timestamps, or creation date.
+`)
+  .option(`--queries [queries...]`, `Raw Appwrite JSON query strings (legacy). Use this for advanced queries or automation; for common filtering, sorting, and pagination prefer --filter, --sort-asc, --sort-desc, --limit, and --offset. When mixed, raw --queries are sent before generated flag queries. Array of query strings generated using the Query class provided by the SDK. Learn more about queries (https://appwrite.io/docs/queries). Maximum of 100 queries are allowed, each 4096 characters long. You may filter on the following attributes: read, type, channel, messageId, projectId, resourceType, resourceId, parentResourceType, parentResourceId, firstSeen, lastSeen`)
+  .option(`--filter <expression>`, `Filter using a simple comparison expression. Repeat for multiple filters. Supports field=value, field!=value, field>value, field>=value, field<value, and field<=value.`, (value: string, previous: string[] | undefined) => collectQueryValue(parseFilterQuery(value), previous))
+  .option(`--where <expression>`, `Deprecated. Use --filter instead. Filter using a simple comparison expression. Repeat for multiple filters.`, (value: string, previous: string[] | undefined) => collectQueryValue(parseDeprecatedWhereQuery(value), previous))
+  .option(`--sort-asc <attribute>`, `Sort results by an attribute in ascending order. Repeat for multiple sort fields.`, (value: string, previous: string[] | undefined) => collectQueryValue(value, previous))
+  .option(`--sort-desc <attribute>`, `Sort results by an attribute in descending order. Repeat for multiple sort fields.`, (value: string, previous: string[] | undefined) => collectQueryValue(value, previous))
+  .option(`--limit <limit>`, `Maximum number of results to return.`, parseInteger)
+  .option(`--offset <offset>`, `Number of results to skip.`, parseInteger)
+  .option(`--cursor-after <id>`, `Return results after this cursor ID.`)
+  .option(`--cursor-before <id>`, `Return results before this cursor ID.`)
+  .action(
+    actionRunner(
+      async ({ queries, filter, where, sortAsc, sortDesc, cursorAfter, cursorBefore, limit, offset }) =>
+        parse(await (await getNotificationsClient()).list(buildQueries({ queries, filter, where, sortAsc, sortDesc, cursorAfter, cursorBefore, limit, offset }))),
+    ),
+  );
+
+
+const notificationsUpdateCommand = notifications
+  .command(`update`)
+  .description(`Update a notification by its unique ID. Use the \`read\` parameter to mark the notification as read or unread.
+`)
+  .requiredOption(`--notification-id <notification-id>`, `Notification ID.`)
+  .requiredOption(`--read <read>`, `Notification read status.`, parseBool)
+  .action(
+    actionRunner(
+      async ({ notificationId, read }) =>
+        parse(await (await getNotificationsClient()).update(notificationId, read)),
+    ),
+  );
+
+

--- a/lib/commands/services/oauth-2.ts
+++ b/lib/commands/services/oauth-2.ts
@@ -29,9 +29,9 @@ export const oauth2 = new Command("oauth-2")
 const oauth2AuthorizeCommand = oauth2
   .command(`authorize`)
   .description(`Begin the OAuth2 authorization flow. When called without a session, the user is redirected to the consent screen without grant ID. When called with a session, the redirect URL includes param for grant ID. You can pass Accept header of \`application/json\` to receive a JSON response instead of a redirect.`)
-  .requiredOption(`--client-_id <client-_id>`, `OAuth2 client ID.`)
-  .requiredOption(`--redirect-_uri <redirect-_uri>`, `Redirect URI where visitor will be redirected after authorization, whether successful or not.`)
-  .requiredOption(`--response-_type <response-_type>`, `OAuth2 / OIDC response type. One of \`code\` (Authorization Code Flow), \`id_token\` (Implicit Flow, OIDC login only), or \`code id_token\` (Hybrid Flow).`)
+  .option(`--client-_id <client-_id>`, `OAuth2 client ID.`)
+  .option(`--redirect-_uri <redirect-_uri>`, `Redirect URI where visitor will be redirected after authorization, whether successful or not.`)
+  .option(`--response-_type <response-_type>`, `OAuth2 / OIDC response type. One of \`code\` (Authorization Code Flow), \`id_token\` (Implicit Flow, OIDC login only), or \`code id_token\` (Hybrid Flow).`)
   .option(`--scope <scope>`, `Space-separated OAuth2 scopes. Can include project scopes, and built-in scopes: \`openid\`, \`email\`, \`profile\`, \`phone\`.`)
   .option(`--state <state>`, `OAuth2 state. You receive this back in the redirect URI.`)
   .option(`--nonce <nonce>`, `OIDC nonce parameter to prevent replay attacks. Required when response_type includes \`id_token\`.`)
@@ -41,10 +41,11 @@ const oauth2AuthorizeCommand = oauth2
   .option(`--max-_age <max-_age>`, `OIDC max_age paraleter for customization of consent screen. Maximum allowable elapsed time in seconds since the user last authenticated. If exceeded, re-authentication is required.`, parseInteger)
   .option(`--authorization-_details <authorization-_details>`, `Rich authorization request. JSON array of objects, each with a \`type\` and project-defined fields`)
   .option(`--resource <resource>`, `RFC 8707 resource indicator URI or URI list. Each value must be an absolute URI without a fragment.`)
+  .option(`--request-_uri <request-_uri>`, `OAuth2 authorization request handle returned by the pushed authorization request endpoint.`)
   .action(
     actionRunner(
-      async ({ client_id, redirect_uri, response_type, scope, state, nonce, code_challenge, code_challenge_method, prompt, max_age, authorization_details, resource }) =>
-        parse(await (await getOauth2Client()).authorize(client_id, redirect_uri, response_type, scope, state, nonce, code_challenge, code_challenge_method, prompt, max_age, authorization_details, resource)),
+      async ({ client_id, redirect_uri, response_type, scope, state, nonce, code_challenge, code_challenge_method, prompt, max_age, authorization_details, resource, request_uri }) =>
+        parse(await (await getOauth2Client()).authorize(client_id, redirect_uri, response_type, scope, state, nonce, code_challenge, code_challenge_method, prompt, max_age, authorization_details, resource, request_uri)),
     ),
   );
 
@@ -101,6 +102,57 @@ const oauth2LogoutCommand = oauth2
     actionRunner(
       async ({ id_token_hint, logout_hint, client_id, post_logout_redirect_uri, state, ui_locales }) =>
         parse(await (await getOauth2Client()).logout(id_token_hint, logout_hint, client_id, post_logout_redirect_uri, state, ui_locales)),
+    ),
+  );
+
+
+const oauth2ListOrganizationsCommand = oauth2
+  .command(`list-organizations`)
+  .description(`List the organizations the OAuth2 access token can access. Resolves the token's \`organization\` authorization details, expanding the \`*\` wildcard into the concrete set of organizations the user can see.`)
+  .option(`--limit <limit>`, `Maximum number of organizations to return. Between 1 and 5000.`, parseInteger)
+  .option(`--offset <offset>`, `Number of organizations to skip before returning results. Used for pagination.`, parseInteger)
+  .option(`--search <search>`, `Search term to filter your list results. Max length: 256 chars.`)
+  .action(
+    actionRunner(
+      async ({ limit, offset, search }) =>
+        parse(await (await getOauth2Client()).listOrganizations(limit, offset, search)),
+    ),
+  );
+
+
+const oauth2CreatePARCommand = oauth2
+  .command(`create-par`)
+  .description(`Store an OAuth2 authorization request server-side and receive a short-lived request_uri handle for the authorize endpoint.`)
+  .requiredOption(`--client-_id <client-_id>`, `OAuth2 client ID.`)
+  .requiredOption(`--redirect-_uri <redirect-_uri>`, `Redirect URI where visitor will be redirected after authorization, whether successful or not.`)
+  .requiredOption(`--response-_type <response-_type>`, `OAuth2 / OIDC response type.`)
+  .requiredOption(`--scope <scope>`, `Space-separated OAuth2 scopes. Can include project scopes, and built-in scopes: \`openid\`, \`email\`, \`profile\`, \`phone\`.`)
+  .option(`--state <state>`, `OAuth2 state. You receive this back in the redirect URI.`)
+  .option(`--nonce <nonce>`, `OIDC nonce parameter to prevent replay attacks. Required when response_type includes \`id_token\`.`)
+  .option(`--code-_challenge <code-_challenge>`, `PKCE code challenge. Required when OAuth2 app is public.`)
+  .option(`--code-_challenge-_method <code-_challenge-_method>`, `PKCE code challenge method. Required when OAuth2 app is public.`)
+  .option(`--prompt <prompt>`, `OIDC prompt parameter for customization of consent screen. Space-separated list of: none, login, consent, select_account.`)
+  .option(`--max-_age <max-_age>`, `OIDC max_age parameter for customization of consent screen.`, parseInteger)
+  .option(`--authorization-_details <authorization-_details>`, `Rich authorization request. JSON array of objects, each with a \`type\` and project-defined fields`)
+  .option(`--resource <resource>`, `RFC 8707 resource indicator URI or URI list. Each value must be an absolute URI without a fragment.`)
+  .action(
+    actionRunner(
+      async ({ client_id, redirect_uri, response_type, scope, state, nonce, code_challenge, code_challenge_method, prompt, max_age, authorization_details, resource }) =>
+        parse(await (await getOauth2Client()).createPAR(client_id, redirect_uri, response_type, scope, state, nonce, code_challenge, code_challenge_method, prompt, max_age, authorization_details, resource)),
+    ),
+  );
+
+
+const oauth2ListProjectsCommand = oauth2
+  .command(`list-projects`)
+  .description(`List the projects the OAuth2 access token can access. Resolves the token's \`project\` authorization details, expanding the \`*\` wildcard into the concrete set of projects the user can see.`)
+  .option(`--limit <limit>`, `Maximum number of projects to return. Between 1 and 5000.`, parseInteger)
+  .option(`--offset <offset>`, `Number of projects to skip before returning results. Used for pagination.`, parseInteger)
+  .option(`--search <search>`, `Search term to filter your list results. Max length: 256 chars.`)
+  .action(
+    actionRunner(
+      async ({ limit, offset, search }) =>
+        parse(await (await getOauth2Client()).listProjects(limit, offset, search)),
     ),
   );
 

--- a/lib/commands/services/organization.ts
+++ b/lib/commands/services/organization.ts
@@ -32,6 +32,38 @@ export const organization = new Command("organization")
     helpWidth: process.stdout.columns || 80,
   });
 
+const organizationGetCommand = organization
+  .command(`get`)
+  .description(`Get the current organization.`)
+  .action(
+    actionRunner(
+      async () => parse(await (await getOrganizationClient()).get()),
+    ),
+  );
+
+
+const organizationUpdateCommand = organization
+  .command(`update`)
+  .description(`Update the current organization's name.`)
+  .requiredOption(`--name <name>`, `New organization name. Max length: 128 chars.`)
+  .action(
+    actionRunner(
+      async ({ name }) =>
+        parse(await (await getOrganizationClient()).update(name)),
+    ),
+  );
+
+
+const organizationDeleteCommand = organization
+  .command(`delete`)
+  .description(`Delete the current organization. All projects that belong to the organization are deleted as well.`)
+  .action(
+    actionRunner(
+      async () => parse(await (await getOrganizationClient()).delete()),
+    ),
+  );
+
+
 const organizationListKeysCommand = organization
   .command(`list-keys`)
   .description(`Get a list of all API keys from the current organization.`)
@@ -108,6 +140,87 @@ const organizationDeleteKeyCommand = organization
     actionRunner(
       async ({ keyId }) =>
         parse(await (await getOrganizationClient()).deleteKey(keyId)),
+    ),
+  );
+
+
+const organizationListMembershipsCommand = organization
+  .command(`list-memberships`)
+  .description(`Get a list of all memberships from the current organization.`)
+  .option(`--queries [queries...]`, `Raw Appwrite JSON query strings (legacy). Use this for advanced queries or automation; for common filtering, sorting, and pagination prefer --filter, --sort-asc, --sort-desc, --limit, and --offset. When mixed, raw --queries are sent before generated flag queries. Array of query strings generated using the Query class provided by the SDK. Learn more about queries (https://appwrite.io/docs/queries). Maximum of 100 queries are allowed, each 4096 characters long. You may filter on the following attributes: userId, teamId, invited, joined, confirm, roles`)
+  .option(`--search <search>`, `Search term to filter your list results. Max length: 256 chars.`)
+  .option(
+    `--total [value]`,
+    `When set to false, the total count returned will be 0 and will not be calculated.`,
+    (value: string | undefined) =>
+      value === undefined ? true : parseBool(value),
+  )
+  .option(`--filter <expression>`, `Filter using a simple comparison expression. Repeat for multiple filters. Supports field=value, field!=value, field>value, field>=value, field<value, and field<=value.`, (value: string, previous: string[] | undefined) => collectQueryValue(parseFilterQuery(value), previous))
+  .option(`--where <expression>`, `Deprecated. Use --filter instead. Filter using a simple comparison expression. Repeat for multiple filters.`, (value: string, previous: string[] | undefined) => collectQueryValue(parseDeprecatedWhereQuery(value), previous))
+  .option(`--sort-asc <attribute>`, `Sort results by an attribute in ascending order. Repeat for multiple sort fields.`, (value: string, previous: string[] | undefined) => collectQueryValue(value, previous))
+  .option(`--sort-desc <attribute>`, `Sort results by an attribute in descending order. Repeat for multiple sort fields.`, (value: string, previous: string[] | undefined) => collectQueryValue(value, previous))
+  .option(`--limit <limit>`, `Maximum number of results to return.`, parseInteger)
+  .option(`--offset <offset>`, `Number of results to skip.`, parseInteger)
+  .option(`--cursor-after <id>`, `Return results after this cursor ID.`)
+  .option(`--cursor-before <id>`, `Return results before this cursor ID.`)
+  .action(
+    actionRunner(
+      async ({ queries, search, total, filter, where, sortAsc, sortDesc, cursorAfter, cursorBefore, limit, offset }) =>
+        parse(await (await getOrganizationClient()).listMemberships(buildQueries({ queries, filter, where, sortAsc, sortDesc, cursorAfter, cursorBefore, limit, offset }), search, total)),
+    ),
+  );
+
+
+const organizationCreateMembershipCommand = organization
+  .command(`create-membership`)
+  .description(`Invite a new member to join the current organization. An email with a link to join the organization will be sent to the new member's email address. If member doesn't exist in the project it will be automatically created.`)
+  .requiredOption(`--roles [roles...]`, `Array of strings. Use this param to set the user roles in the organization. A role can be any string. Learn more about roles and permissions (https://appwrite.io/docs/permissions). Maximum of 100 roles are allowed, each 81 characters long.`)
+  .option(`--email <email>`, `Email of the new organization member.`)
+  .option(`--user-id <user-id>`, `ID of the user to be added to the organization.`)
+  .option(`--phone <phone>`, `Phone number. Format this number with a leading '+' and a country code, e.g., +16175551212.`)
+  .option(`--url <url>`, `URL to redirect the user back to your app from the invitation email. This parameter is not required when an API key is supplied.`)
+  .option(`--name <name>`, `Name of the new organization member. Max length: 128 chars.`)
+  .action(
+    actionRunner(
+      async ({ roles, email, userId, phone, url, name }) =>
+        parse(await (await getOrganizationClient()).createMembership(roles, email, userId, phone, url, name)),
+    ),
+  );
+
+
+const organizationGetMembershipCommand = organization
+  .command(`get-membership`)
+  .description(`Get a membership from the current organization by its unique ID.`)
+  .requiredOption(`--membership-id <membership-id>`, `Membership ID.`)
+  .action(
+    actionRunner(
+      async ({ membershipId }) =>
+        parse(await (await getOrganizationClient()).getMembership(membershipId)),
+    ),
+  );
+
+
+const organizationUpdateMembershipCommand = organization
+  .command(`update-membership`)
+  .description(`Modify the roles of a member in the current organization.`)
+  .requiredOption(`--membership-id <membership-id>`, `Membership ID.`)
+  .requiredOption(`--roles [roles...]`, `An array of strings. Use this param to set the user's roles in the organization. A role can be any string. Learn more about roles and permissions (https://appwrite.io/docs/permissions). Maximum of 100 roles are allowed, each 81 characters long.`)
+  .action(
+    actionRunner(
+      async ({ membershipId, roles }) =>
+        parse(await (await getOrganizationClient()).updateMembership(membershipId, roles)),
+    ),
+  );
+
+
+const organizationDeleteMembershipCommand = organization
+  .command(`delete-membership`)
+  .description(`Remove a member from the current organization. The member is removed whether they accepted the invitation or not; a pending invitation is revoked.`)
+  .requiredOption(`--membership-id <membership-id>`, `Membership ID.`)
+  .action(
+    actionRunner(
+      async ({ membershipId }) =>
+        parse(await (await getOrganizationClient()).deleteMembership(membershipId)),
     ),
   );
 

--- a/lib/commands/services/organizations.ts
+++ b/lib/commands/services/organizations.ts
@@ -130,6 +130,19 @@ const organizationsCreateBaaAddonCommand = organizations
   );
 
 
+const organizationsCreatePremiumGeoDBAddonCommand = organizations
+  .command(`create-premium-geo-db-addon`)
+  .description(`Create a Premium Geo DB addon for an organization.
+`)
+  .requiredOption(`--organization-id <organization-id>`, `Organization ID`)
+  .action(
+    actionRunner(
+      async ({ organizationId }) =>
+        parse(await (await getOrganizationsClient()).createPremiumGeoDBAddon(organizationId)),
+    ),
+  );
+
+
 const organizationsGetAddonCommand = organizations
   .command(`get-addon`)
   .description(`Get the details of a billing addon for an organization.

--- a/lib/commands/services/project.ts
+++ b/lib/commands/services/project.ts
@@ -768,6 +768,8 @@ const projectUpdateOAuth2OidcCommand = project
   .option(`--authorization-url <authorization-url>`, `OpenID Connect authorization endpoint URL. Required when wellKnownURL is not provided. For example: https://myoauth.com/oauth2/authorize`)
   .option(`--token-url <token-url>`, `OpenID Connect token endpoint URL. Required when wellKnownURL is not provided. For example: https://myoauth.com/oauth2/token`)
   .option(`--user-info-url <user-info-url>`, `OpenID Connect user info endpoint URL. Required when wellKnownURL is not provided. For example: https://myoauth.com/oauth2/userinfo`)
+  .option(`--prompt [prompt...]`, `Array of OpenID Connect prompt values controlling the authentication and consent screens. If "none" is included, it must be the only element. "none" means: don't display any authentication or consent screens. "login" means: prompt the user to re-authenticate. "consent" means: prompt the user for consent. "select_account" means: prompt the user to select an account.`)
+  .option(`--max-age <max-age>`, `Maximum authentication age in seconds. When set, the user must have authenticated within this many seconds, otherwise they are prompted to re-authenticate.`, parseInteger)
   .option(
     `--enabled [value]`,
     `OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid.`,
@@ -776,8 +778,8 @@ const projectUpdateOAuth2OidcCommand = project
   )
   .action(
     actionRunner(
-      async ({ clientId, clientSecret, wellKnownUrl, authorizationUrl, tokenUrl, userInfoUrl, enabled }) =>
-        parse(await (await getProjectClient()).updateOAuth2Oidc(clientId, clientSecret, wellKnownUrl, authorizationUrl, tokenUrl, userInfoUrl, enabled)),
+      async ({ clientId, clientSecret, wellKnownUrl, authorizationUrl, tokenUrl, userInfoUrl, prompt, maxAge, enabled }) =>
+        parse(await (await getProjectClient()).updateOAuth2Oidc(clientId, clientSecret, wellKnownUrl, authorizationUrl, tokenUrl, userInfoUrl, prompt, maxAge, enabled)),
     ),
   );
 

--- a/lib/commands/services/projects.ts
+++ b/lib/commands/services/projects.ts
@@ -33,6 +33,88 @@ export const projects = new Command("projects")
     helpWidth: process.stdout.columns || 80,
   });
 
+const projectsListAddonsCommand = projects
+  .command(`list-addons`)
+  .description(`List all billing addons for a project.
+`)
+  .requiredOption(`--project-id <project-id>`, `Project ID`)
+  .action(
+    actionRunner(
+      async ({ projectId }) =>
+        parse(await (await getProjectsClient()).listAddons(projectId)),
+    ),
+  );
+
+
+const projectsCreatePremiumGeoDBAddonCommand = projects
+  .command(`create-premium-geo-db-addon`)
+  .description(`Create a Premium Geo DB addon for a project.
+`)
+  .requiredOption(`--project-id <project-id>`, `Project ID`)
+  .action(
+    actionRunner(
+      async ({ projectId }) =>
+        parse(await (await getProjectsClient()).createPremiumGeoDBAddon(projectId)),
+    ),
+  );
+
+
+const projectsGetAddonCommand = projects
+  .command(`get-addon`)
+  .description(`Get the details of a billing addon for a project.
+`)
+  .requiredOption(`--project-id <project-id>`, `Project ID`)
+  .requiredOption(`--addon-id <addon-id>`, `Addon ID`)
+  .action(
+    actionRunner(
+      async ({ projectId, addonId }) =>
+        parse(await (await getProjectsClient()).getAddon(projectId, addonId)),
+    ),
+  );
+
+
+const projectsDeleteAddonCommand = projects
+  .command(`delete-addon`)
+  .description(`Delete a billing addon for a project.
+`)
+  .requiredOption(`--project-id <project-id>`, `Project ID`)
+  .requiredOption(`--addon-id <addon-id>`, `Addon ID`)
+  .action(
+    actionRunner(
+      async ({ projectId, addonId }) =>
+        parse(await (await getProjectsClient()).deleteAddon(projectId, addonId)),
+    ),
+  );
+
+
+const projectsConfirmAddonPaymentCommand = projects
+  .command(`confirm-addon-payment`)
+  .description(`Confirm payment for a billing addon for a project.
+`)
+  .requiredOption(`--project-id <project-id>`, `Project ID`)
+  .requiredOption(`--addon-id <addon-id>`, `Addon ID`)
+  .action(
+    actionRunner(
+      async ({ projectId, addonId }) =>
+        parse(await (await getProjectsClient()).confirmAddonPayment(projectId, addonId)),
+    ),
+  );
+
+
+const projectsGetAddonPriceCommand = projects
+  .command(`get-addon-price`)
+  .description(`Get the price details for a billing addon for a project, including the prorated amount for the remaining days in the current billing cycle.
+`)
+  .requiredOption(`--project-id <project-id>`, `Project ID`)
+  .requiredOption(`--addon <addon>`, `Addon key identifier (e.g. premiumGeoDB).`)
+  .action(
+    actionRunner(
+      async ({ projectId, addon }) =>
+        parse(await (await getProjectsClient()).getAddonPrice(projectId, addon)),
+    ),
+  );
+
+
 const projectsListDevKeysCommand = projects
   .command(`list-dev-keys`)
   .description(`List all the project\'s dev keys. Dev keys are project specific and allow you to bypass rate limits and get better error logging during development.'`)

--- a/lib/commands/services/tables-db.ts
+++ b/lib/commands/services/tables-db.ts
@@ -72,11 +72,11 @@ const tablesDBCreateCommand = tablesDB
     (value: string | undefined) =>
       value === undefined ? true : parseBool(value),
   )
-  .option(`--dedicated-database-id <dedicated-database-id>`, `Optional dedicated database ID to attach this database to. Leave empty to create a database on the shared pool.`)
+  .option(`--specification <specification>`, `Database specification. Defaults to \`serverless\`, which creates the database on the shared pool. Any other value provisions a dedicated database on that specification.`)
   .action(
     actionRunner(
-      async ({ databaseId, name, enabled, dedicatedDatabaseId }) =>
-        parse(await (await getTablesDBClient()).create(databaseId, name, enabled, dedicatedDatabaseId)),
+      async ({ databaseId, name, enabled, specification }) =>
+        parse(await (await getTablesDBClient()).create(databaseId, name, enabled, specification)),
     ),
   );
 
@@ -225,6 +225,57 @@ const tablesDBDeleteCommand = tablesDB
     actionRunner(
       async ({ databaseId }) =>
         parse(await (await getTablesDBClient()).delete(databaseId)),
+    ),
+  );
+
+
+const tablesDBListMigrationsCommand = tablesDB
+  .command(`list-migrations`)
+  .description(`List the dedicated migrations for a TablesDB database. A database has at most one in-flight migration.`)
+  .requiredOption(`--database-id <database-id>`, `Database ID.`)
+  .action(
+    actionRunner(
+      async ({ databaseId }) =>
+        parse(await (await getTablesDBClient()).listMigrations(databaseId)),
+    ),
+  );
+
+
+const tablesDBCreateMigrationCommand = tablesDB
+  .command(`create-migration`)
+  .description(`Start migrating a serverless TablesDB database onto a dedicated MySQL compute. Data is copied to the target while the source stays live, with a brief read-only window during cutover.`)
+  .requiredOption(`--database-id <database-id>`, `Database ID.`)
+  .requiredOption(`--specification <specification>`, `Dedicated compute specification to provision as the migration target (e.g. s-2vcpu-4gb). The migration always targets a dedicated compute, so \`serverless\` is not accepted.`)
+  .action(
+    actionRunner(
+      async ({ databaseId, specification }) =>
+        parse(await (await getTablesDBClient()).createMigration(databaseId, specification)),
+    ),
+  );
+
+
+const tablesDBGetMigrationCommand = tablesDB
+  .command(`get-migration`)
+  .description(`Get a single dedicated migration for a TablesDB database by its ID.`)
+  .requiredOption(`--database-id <database-id>`, `Database ID.`)
+  .requiredOption(`--migration-id <migration-id>`, `Migration ID.`)
+  .action(
+    actionRunner(
+      async ({ databaseId, migrationId }) =>
+        parse(await (await getTablesDBClient()).getMigration(databaseId, migrationId)),
+    ),
+  );
+
+
+const tablesDBDeleteMigrationCommand = tablesDB
+  .command(`delete-migration`)
+  .description(`Abort an in-flight TablesDB dedicated migration. Only allowed before cutover; once the migration has cut over it cannot be aborted.`)
+  .requiredOption(`--database-id <database-id>`, `Database ID.`)
+  .requiredOption(`--migration-id <migration-id>`, `Migration ID.`)
+  .action(
+    actionRunner(
+      async ({ databaseId, migrationId }) =>
+        parse(await (await getTablesDBClient()).deleteMigration(databaseId, migrationId)),
     ),
   );
 

--- a/lib/commands/services/teams.ts
+++ b/lib/commands/services/teams.ts
@@ -120,6 +120,27 @@ const teamsDeleteCommand = teams
   );
 
 
+const teamsListLogsCommand = teams
+  .command(`list-logs`)
+  .description(`Get the team activity logs list by its unique ID.`)
+  .requiredOption(`--team-id <team-id>`, `Team ID.`)
+  .option(`--queries [queries...]`, `Raw Appwrite JSON query strings (legacy). Use this for advanced queries or automation; for common pagination prefer --limit and --offset. When mixed, raw --queries are sent before generated flag queries. Array of query strings generated using the Query class provided by the SDK. Learn more about queries (https://appwrite.io/docs/queries). Only supported methods are limit and offset`)
+  .option(
+    `--total [value]`,
+    `When set to false, the total count returned will be 0 and will not be calculated.`,
+    (value: string | undefined) =>
+      value === undefined ? true : parseBool(value),
+  )
+  .option(`--limit <limit>`, `Maximum number of results to return.`, parseInteger)
+  .option(`--offset <offset>`, `Number of results to skip.`, parseInteger)
+  .action(
+    actionRunner(
+      async ({ teamId, queries, total, limit, offset }) =>
+        parse(await (await getTeamsClient()).listLogs(teamId, buildQueries({ queries, limit, offset }), total)),
+    ),
+  );
+
+
 const teamsListMembershipsCommand = teams
   .command(`list-memberships`)
   .description(`Use this endpoint to list a team's members using the team's ID. All team members have read access to this endpoint. Hide sensitive attributes from the response by toggling membership privacy in the Console.`)

--- a/lib/commands/services/users.ts
+++ b/lib/commands/services/users.ts
@@ -322,6 +322,27 @@ Labels can be used to grant access to resources. While teams are a way for user'
   );
 
 
+const usersListLogsCommand = users
+  .command(`list-logs`)
+  .description(`Get the user activity logs list by its unique ID.`)
+  .requiredOption(`--user-id <user-id>`, `User ID.`)
+  .option(`--queries [queries...]`, `Raw Appwrite JSON query strings (legacy). Use this for advanced queries or automation; for common pagination prefer --limit and --offset. When mixed, raw --queries are sent before generated flag queries. Array of query strings generated using the Query class provided by the SDK. Learn more about queries (https://appwrite.io/docs/queries). Only supported methods are limit and offset`)
+  .option(
+    `--total [value]`,
+    `When set to false, the total count returned will be 0 and will not be calculated.`,
+    (value: string | undefined) =>
+      value === undefined ? true : parseBool(value),
+  )
+  .option(`--limit <limit>`, `Maximum number of results to return.`, parseInteger)
+  .option(`--offset <offset>`, `Number of results to skip.`, parseInteger)
+  .action(
+    actionRunner(
+      async ({ userId, queries, total, limit, offset }) =>
+        parse(await (await getUsersClient()).listLogs(userId, buildQueries({ queries, limit, offset }), total)),
+    ),
+  );
+
+
 const usersListMembershipsCommand = users
   .command(`list-memberships`)
   .description(`Get the user membership list by its unique ID.`)

--- a/lib/config-filters.ts
+++ b/lib/config-filters.ts
@@ -41,7 +41,9 @@ const configFilters: ConfigFilter[] = [
           new URL(
             `${consoleClient.config.endpoint}/projects/${encodeURIComponent(config.projectId)}`,
           ),
-          {},
+          {
+            "X-Appwrite-Project": "console",
+          },
           {},
         );
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,7 +1,7 @@
 // SDK
 export const SDK_TITLE = 'Appwrite';
 export const SDK_TITLE_LOWER = 'appwrite';
-export const SDK_VERSION = '22.4.0';
+export const SDK_VERSION = '22.5.0';
 export const SDK_NAME = 'Command Line';
 export const SDK_PLATFORM = 'console';
 export const SDK_LANGUAGE = 'cli';
@@ -15,6 +15,7 @@ export const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
 // Homebrew — fully-qualified `<owner>/<tap>/<formula>` reference
 export const HOMEBREW_TAP = 'appwrite/appwrite';
 export const HOMEBREW_FORMULA = `${HOMEBREW_TAP}/appwrite`;
+export const HOMEBREW_TAP_FORMULA_URL = 'https://raw.githubusercontent.com/appwrite/homebrew-appwrite/main/Formula/appwrite.rb';
 
 // NPM
 export const NPM_PACKAGE_NAME = 'appwrite-cli';

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -15,6 +15,7 @@ import {
   DEFAULT_ENDPOINT,
   EXECUTABLE_NAME,
   HOMEBREW_FORMULA,
+  HOMEBREW_TAP_FORMULA_URL,
   UPDATE_CHECK_INTERVAL_MS,
 } from "./constants.js";
 
@@ -343,6 +344,38 @@ const getHomebrewLatestVersion = async (
     options.homebrewFormula ??
     getInstalledHomebrewFormula(options) ??
     HOMEBREW_FORMULA;
+
+  // `brew info` reads the local tap clone, which is only refreshed by
+  // `brew update` and can report a stale version. For the official tap,
+  // resolve the latest version from the tap repo itself and fall back to
+  // local metadata only when the fetch fails (e.g. offline).
+  if (formulaName === HOMEBREW_FORMULA) {
+    try {
+      const signal = AbortSignal.timeout(
+        options.timeoutMs ?? DEFAULT_HOMEBREW_COMMAND_TIMEOUT_MS,
+      );
+
+      const response = await fetch(HOMEBREW_TAP_FORMULA_URL, { signal });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      // Strip resource blocks so their `version` lines cannot shadow the
+      // formula-level version.
+      const formulaSource = (await response.text()).replace(
+        /^\s*resource\s+"[^"]*"\s+do[\s\S]*?^\s*end/gm,
+        "",
+      );
+      const match = formulaSource.match(/^\s*version\s+"([^"]+)"/m);
+      if (!match) {
+        throw new Error("Could not find a version in the tap formula.");
+      }
+
+      return normalizeHomebrewVersion(match[1].trim());
+    } catch (_error) {
+      // Fall through to local Homebrew metadata below.
+    }
+  }
 
   try {
     const output = childProcess.execFileSync(

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "22.5.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@appwrite.io/console": "^15.1.1",
+        "@appwrite.io/console": "15.3.0-rc.1",
         "@napi-rs/keyring": "^1.3.0",
         "chalk": "4.1.2",
         "chokidar": "^3.6.0",
@@ -49,18 +49,12 @@
         "tsx": "^4.21.0",
         "typescript": "^5.3.3",
         "typescript-eslint": "^8.0.0"
-      },
-      "overrides": {
-        "phin": "3.7.1",
-        "@xmldom/xmldom": "^0.9.10",
-        "tmp": "^0.2.6",
-        "esbuild": "^0.28.1"
       }
     },
     "node_modules/@appwrite.io/console": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/@appwrite.io/console/-/console-15.1.1.tgz",
-      "integrity": "sha512-W4t9xNuHoNUYGypcZtgPaHvuS/AFjSdDDleeNQl3cWMiOrS9wasVyIwygAHeQjis9evwPC4WUbfpx8WWYXijDg==",
+      "version": "15.3.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@appwrite.io/console/-/console-15.3.0-rc.1.tgz",
+      "integrity": "sha512-OvjwB0qEzJPFxCc6Hlg1AIU92SRBTjQv+xuXJ80wT7oaxpR4WwULj6qYrQrRe3jzK8OatO+NytZ8OQIgg+nyxg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "json-bigint": "1.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appwrite-cli",
-  "version": "22.4.0",
+  "version": "22.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "appwrite-cli",
-      "version": "22.4.0",
+      "version": "22.5.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@appwrite.io/console": "^15.1.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "windows-arm64": "bun build cli.ts --compile --minify --target=bun-windows-arm64 --outfile build/appwrite-cli-win-arm64.exe"
   },
   "dependencies": {
-    "@appwrite.io/console": "^15.1.1",
+    "@appwrite.io/console": "15.3.0-rc.1",
     "@napi-rs/keyring": "^1.3.0",
     "chalk": "4.1.2",
     "chokidar": "^3.6.0",
@@ -79,20 +79,20 @@
     "esbuild": "^0.28.1"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^8.0.0",
-    "@typescript-eslint/parser": "^8.0.0",
     "@types/bun": "^1.3.5",
-    "eslint": "^9.0.0",
-    "eslint-plugin-unused-imports": "^4.0.0",
-    "typescript-eslint": "^8.0.0",
     "@types/cli-progress": "^3.11.5",
     "@types/inquirer": "^8.2.10",
     "@types/json-bigint": "^1.0.4",
     "@types/node": "^18.19.0",
     "@types/tar": "^6.1.13",
+    "@typescript-eslint/eslint-plugin": "^8.0.0",
+    "@typescript-eslint/parser": "^8.0.0",
     "esbuild": "^0.28.1",
+    "eslint": "^9.0.0",
+    "eslint-plugin-unused-imports": "^4.0.0",
     "prettier": "^3.7.4",
     "tsx": "^4.21.0",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "typescript-eslint": "^8.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "homepage": "https://appwrite.io/support",
   "description": "Appwrite is an open-source self-hosted backend server that abstracts and simplifies complex and repetitive development tasks behind a very simple REST API",
-  "version": "22.4.0",
+  "version": "22.5.0",
   "license": "BSD-3-Clause",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/scoop/appwrite.config.json
+++ b/scoop/appwrite.config.json
@@ -1,12 +1,12 @@
 {
 	"$schema": "https://raw.githubusercontent.com/ScoopInstaller/Scoop/master/schema.json",
-	"version": "22.4.0",
+	"version": "22.5.0",
 	"description": "The Appwrite CLI is a command-line application that allows you to interact with Appwrite and perform server-side tasks using your terminal.",
 	"homepage": "https://github.com/appwrite/sdk-for-cli",
 	"license": "BSD-3-Clause",
 	"architecture": {
 		"64bit": {
-			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/22.4.0/appwrite-cli-win-x64.exe",
+			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/22.5.0/appwrite-cli-win-x64.exe",
 			"bin": [
 				[
 					"appwrite-cli-win-x64.exe",
@@ -15,7 +15,7 @@
 			]
 		},
 		"arm64": {
-			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/22.4.0/appwrite-cli-win-arm64.exe",
+			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/22.5.0/appwrite-cli-win-arm64.exe",
 			"bin": [
 				[
 					"appwrite-cli-win-arm64.exe",


### PR DESCRIPTION
This PR contains updates to the SDK for version 22.5.0.

Built against `@appwrite.io/console@15.3.0-rc.1` (preview published from [`preview-1.9.x-rc`](https://github.com/appwrite/sdk-for-console/tree/preview-1.9.x-rc) under the `next` npm tag).

## What's Changed

* Updated: `tablesdb create` now takes `--specification` instead of `--dedicated-database-id`
* Updated: Removed `health get-queue-logs` command
* Added: `notifications` command group for console notifications
* Added: `organization get`, `update`, and `delete` commands
* Added: `organization list-memberships`, `create-membership`, `get-membership`, `update-membership`, and `delete-membership` commands
* Added: `tablesdb list-migrations`, `create-migration`, `get-migration`, and `delete-migration` commands for dedicated database migrations
* Added: `oauth2 create-par`, `list-organizations`, and `list-projects` commands
* Added: `--request-_uri` option on `oauth2 authorize`; client ID, redirect URI, and response type are now optional
* Added: `projects list-addons`, `get-addon`, `delete-addon`, `confirm-addon-payment`, and `get-addon-price` commands
* Added: `create-premium-geo-db-addon` command on `projects` and `organizations`
* Added: `account list-logs`, `teams list-logs`, and `users list-logs` commands
* Added: `health get-geo` and `get-geo-premium` commands
* Added: `--new-specification` option on `backups create-restoration`
* Added: `--prompt` and `--max-age` options on `project update-o-auth-2-oidc`
* Fixed: Project config validation now sends the `X-Appwrite-Project` header, fixing 401 errors for guest sessions
* Fixed: Update check now reads the latest version from the Homebrew tap instead of stale local metadata