### PR TITLE
feat: SDK update for version 22.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## 22.7.0
+## 22.6.1
 
 * Fixed: snake_case parameters now map to proper kebab-case flags: `oauth2` commands use `--client-id`, `--redirect-uri`, `--response-type`, `--request-uri`, `--code-challenge`, `--max-age` instead of the malformed `--client-_id` style names
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 22.7.0
+
+* Fixed: snake_case parameters now map to proper kebab-case flags: `oauth2` commands use `--client-id`, `--redirect-uri`, `--response-type`, `--request-uri`, `--code-challenge`, `--max-age` instead of the malformed `--client-_id` style names
+
 ## 22.6.0
 
 * Added: `push functions` and `pull` now work with API key authentication, enabling CI usage without a console session

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Once the installation is complete, you can verify the install using
 
 ```sh
 $ appwrite -v
-22.7.0
+22.6.1
 ```
 
 ### Install using prebuilt binaries
@@ -83,7 +83,7 @@ $ scoop install https://raw.githubusercontent.com/appwrite/sdk-for-cli/master/sc
 Once the installation completes, you can verify your install using
 ```
 $ appwrite -v
-22.7.0
+22.6.1
 ```
 
 ## Getting Started 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Once the installation is complete, you can verify the install using
 
 ```sh
 $ appwrite -v
-22.6.0
+22.7.0
 ```
 
 ### Install using prebuilt binaries
@@ -83,7 +83,7 @@ $ scoop install https://raw.githubusercontent.com/appwrite/sdk-for-cli/master/sc
 Once the installation completes, you can verify your install using
 ```
 $ appwrite -v
-22.6.0
+22.7.0
 ```
 
 ## Getting Started 

--- a/bun.lock
+++ b/bun.lock
@@ -624,7 +624,7 @@
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
-    "prettier": ["prettier@3.9.4", "", { "bin": "bin/prettier.cjs" }, "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg=="],
+    "prettier": ["prettier@3.9.5", "", { "bin": "bin/prettier.cjs" }, "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg=="],
 
     "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
 
@@ -764,7 +764,11 @@
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
+    "@eslint/config-array/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
     "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "@eslint/eslintrc/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "@isaacs/fs-minipass/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
@@ -868,6 +872,8 @@
 
     "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
+    "espree/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
+
     "external-editor/chardet": ["chardet@0.4.2", "", {}, "sha512-j/Toj7f1z98Hh2cYo2BVr85EpIRWqUi7rtRSGxh/cqUjqrnJe9l9UE7IUGd2vQ2p+kSHLkSzObQPZPLUC6TQwg=="],
 
     "external-editor/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
@@ -922,6 +928,10 @@
 
     "xml2js/xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
 
+    "@eslint/config-array/minimatch/brace-expansion": ["brace-expansion@1.1.16", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw=="],
+
+    "@eslint/eslintrc/minimatch/brace-expansion": ["brace-expansion@1.1.16", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw=="],
+
     "@jimp/custom/@jimp/core/@jimp/utils": ["@jimp/utils@0.14.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "regenerator-runtime": "^0.13.3" } }, "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A=="],
 
     "@jimp/custom/@jimp/core/file-type": ["file-type@9.0.0", "", {}, "sha512-Qe/5NJrgIOlwijpq3B7BEpzPFcgzggOTagZmkXQY4LA6bsXKTUstK7Wp12lEJ/mLKTpvIZxmIuRcLYWT6ov9lw=="],
@@ -966,6 +976,8 @@
 
     "cli-table3/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
+    "cli-table3/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
     "filelist/minimatch/brace-expansion": ["brace-expansion@2.1.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA=="],
 
     "inquirer-search-list/chalk/ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
@@ -990,6 +1002,8 @@
 
     "inquirer/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
+    "inquirer/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
     "log-update/cli-cursor/restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
     "log-update/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
@@ -1002,9 +1016,17 @@
 
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
+    "wrap-ansi/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "@eslint/config-array/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "@eslint/eslintrc/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
     "@jimp/custom/@jimp/core/pixelmatch/pngjs": ["pngjs@3.4.0", "", {}, "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "filelist/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "inquirer-search-list/chalk/ansi-styles/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
 

--- a/install.ps1
+++ b/install.ps1
@@ -13,8 +13,8 @@
 # You can use "View source" of this page to see the full script.
 
 # REPO
-$GITHUB_x64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/22.6.0/appwrite-cli-win-x64.exe"
-$GITHUB_arm64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/22.6.0/appwrite-cli-win-arm64.exe"
+$GITHUB_x64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/22.7.0/appwrite-cli-win-x64.exe"
+$GITHUB_arm64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/22.7.0/appwrite-cli-win-arm64.exe"
 
 $APPWRITE_BINARY_NAME = "appwrite.exe"
 

--- a/install.ps1
+++ b/install.ps1
@@ -13,8 +13,8 @@
 # You can use "View source" of this page to see the full script.
 
 # REPO
-$GITHUB_x64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/22.7.0/appwrite-cli-win-x64.exe"
-$GITHUB_arm64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/22.7.0/appwrite-cli-win-arm64.exe"
+$GITHUB_x64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/22.6.1/appwrite-cli-win-x64.exe"
+$GITHUB_arm64_URL = "https://github.com/appwrite/sdk-for-cli/releases/download/22.6.1/appwrite-cli-win-arm64.exe"
 
 $APPWRITE_BINARY_NAME = "appwrite.exe"
 

--- a/install.sh
+++ b/install.sh
@@ -120,7 +120,7 @@ verifyMacOSCodeSignature() {
 downloadBinary() {
     echo "[2/5] Downloading executable for $OS ($ARCH) ..."
 
-    GITHUB_LATEST_VERSION="22.7.0"
+    GITHUB_LATEST_VERSION="22.6.1"
     GITHUB_FILE="appwrite-cli-${OS}-${ARCH}"
     GITHUB_URL="https://github.com/$GITHUB_REPOSITORY_NAME/releases/download/$GITHUB_LATEST_VERSION/$GITHUB_FILE"
 

--- a/install.sh
+++ b/install.sh
@@ -120,7 +120,7 @@ verifyMacOSCodeSignature() {
 downloadBinary() {
     echo "[2/5] Downloading executable for $OS ($ARCH) ..."
 
-    GITHUB_LATEST_VERSION="22.6.0"
+    GITHUB_LATEST_VERSION="22.7.0"
     GITHUB_FILE="appwrite-cli-${OS}-${ARCH}"
     GITHUB_URL="https://github.com/$GITHUB_REPOSITORY_NAME/releases/download/$GITHUB_LATEST_VERSION/$GITHUB_FILE"
 

--- a/lib/commands/services/oauth-2.ts
+++ b/lib/commands/services/oauth-2.ts
@@ -29,23 +29,23 @@ export const oauth2 = new Command("oauth-2")
 const oauth2AuthorizeCommand = oauth2
   .command(`authorize`)
   .description(`Begin the OAuth2 authorization flow. When called without a session, the user is redirected to the consent screen without grant ID. When called with a session, the redirect URL includes param for grant ID. You can pass Accept header of \`application/json\` to receive a JSON response instead of a redirect.`)
-  .option(`--client-_id <client-_id>`, `OAuth2 client ID.`)
-  .option(`--redirect-_uri <redirect-_uri>`, `Redirect URI where visitor will be redirected after authorization, whether successful or not.`)
-  .option(`--response-_type <response-_type>`, `OAuth2 / OIDC response type. One of \`code\` (Authorization Code Flow), \`id_token\` (Implicit Flow, OIDC login only), or \`code id_token\` (Hybrid Flow).`)
+  .option(`--client-id <client-id>`, `OAuth2 client ID.`)
+  .option(`--redirect-uri <redirect-uri>`, `Redirect URI where visitor will be redirected after authorization, whether successful or not.`)
+  .option(`--response-type <response-type>`, `OAuth2 / OIDC response type. One of \`code\` (Authorization Code Flow), \`id_token\` (Implicit Flow, OIDC login only), or \`code id_token\` (Hybrid Flow).`)
   .option(`--scope <scope>`, `Space-separated OAuth2 scopes. Can include project scopes, and built-in scopes: \`openid\`, \`email\`, \`profile\`, \`phone\`.`)
   .option(`--state <state>`, `OAuth2 state. You receive this back in the redirect URI.`)
   .option(`--nonce <nonce>`, `OIDC nonce parameter to prevent replay attacks. Required when response_type includes \`id_token\`.`)
-  .option(`--code-_challenge <code-_challenge>`, `PKCE code challenge. Required when OAuth2 app is public.`)
-  .option(`--code-_challenge-_method <code-_challenge-_method>`, `PKCE code challenge method. Required when OAuth2 app is public.`)
+  .option(`--code-challenge <code-challenge>`, `PKCE code challenge. Required when OAuth2 app is public.`)
+  .option(`--code-challenge-method <code-challenge-method>`, `PKCE code challenge method. Required when OAuth2 app is public.`)
   .option(`--prompt <prompt>`, `OIDC prompt parameter for customization of consent screen. Space-separated list of: none, login, consent, select_account.`)
-  .option(`--max-_age <max-_age>`, `OIDC max_age paraleter for customization of consent screen. Maximum allowable elapsed time in seconds since the user last authenticated. If exceeded, re-authentication is required.`, parseInteger)
-  .option(`--authorization-_details <authorization-_details>`, `Rich authorization request. JSON array of objects, each with a \`type\` and project-defined fields`)
+  .option(`--max-age <max-age>`, `OIDC max_age paraleter for customization of consent screen. Maximum allowable elapsed time in seconds since the user last authenticated. If exceeded, re-authentication is required.`, parseInteger)
+  .option(`--authorization-details <authorization-details>`, `Rich authorization request. JSON array of objects, each with a \`type\` and project-defined fields`)
   .option(`--resource <resource>`, `RFC 8707 resource indicator URI or URI list. Each value must be an absolute URI without a fragment.`)
-  .option(`--request-_uri <request-_uri>`, `OAuth2 authorization request handle returned by the pushed authorization request endpoint.`)
+  .option(`--request-uri <request-uri>`, `OAuth2 authorization request handle returned by the pushed authorization request endpoint.`)
   .action(
     actionRunner(
-      async ({ client_id, redirect_uri, response_type, scope, state, nonce, code_challenge, code_challenge_method, prompt, max_age, authorization_details, resource, request_uri }) =>
-        parse(await (await getOauth2Client()).authorize(client_id, redirect_uri, response_type, scope, state, nonce, code_challenge, code_challenge_method, prompt, max_age, authorization_details, resource, request_uri)),
+      async ({ clientId, redirectUri, responseType, scope, state, nonce, codeChallenge, codeChallengeMethod, prompt, maxAge, authorizationDetails, resource, requestUri }) =>
+        parse(await (await getOauth2Client()).authorize(clientId, redirectUri, responseType, scope, state, nonce, codeChallenge, codeChallengeMethod, prompt, maxAge, authorizationDetails, resource, requestUri)),
     ),
   );
 
@@ -53,14 +53,14 @@ const oauth2AuthorizeCommand = oauth2
 const oauth2CreateDeviceAuthorizationCommand = oauth2
   .command(`create-device-authorization`)
   .description(`Start the OAuth2 Device Authorization Grant. Returns the device code, user code, verification URL, expiration, and polling interval.`)
-  .option(`--client-_id <client-_id>`, `OAuth2 client ID.`)
+  .option(`--client-id <client-id>`, `OAuth2 client ID.`)
   .option(`--scope <scope>`, `Space-separated OAuth2 scopes. Can include project scopes, and built-in scopes: \`openid\`, \`email\`, \`profile\`.`)
-  .option(`--authorization-_details <authorization-_details>`, `Rich authorization request. JSON array of objects, each with a \`type\` and project-defined fields`)
+  .option(`--authorization-details <authorization-details>`, `Rich authorization request. JSON array of objects, each with a \`type\` and project-defined fields`)
   .option(`--resource <resource>`, `RFC 8707 resource indicator URI or URI list. Each value must be an absolute URI without a fragment.`)
   .action(
     actionRunner(
-      async ({ client_id, scope, authorization_details, resource }) =>
-        parse(await (await getOauth2Client()).createDeviceAuthorization(client_id, scope, authorization_details, resource)),
+      async ({ clientId, scope, authorizationDetails, resource }) =>
+        parse(await (await getOauth2Client()).createDeviceAuthorization(clientId, scope, authorizationDetails, resource)),
     ),
   );
 
@@ -68,11 +68,11 @@ const oauth2CreateDeviceAuthorizationCommand = oauth2
 const oauth2CreateGrantCommand = oauth2
   .command(`create-grant`)
   .description(`Exchange a device flow user code for an OAuth2 grant. The authenticated user is bound to the pending grant. Pass the returned grant ID to the get grant endpoint to render the consent screen, then to the approve or reject endpoint to complete the flow.`)
-  .requiredOption(`--user-_code <user-_code>`, `User code displayed on the device.`)
+  .requiredOption(`--user-code <user-code>`, `User code displayed on the device.`)
   .action(
     actionRunner(
-      async ({ user_code }) =>
-        parse(await (await getOauth2Client()).createGrant(user_code)),
+      async ({ userCode }) =>
+        parse(await (await getOauth2Client()).createGrant(userCode)),
     ),
   );
 
@@ -80,11 +80,11 @@ const oauth2CreateGrantCommand = oauth2
 const oauth2GetGrantCommand = oauth2
   .command(`get-grant`)
   .description(`Get an OAuth2 grant by its ID. Used by the consent screen to display the details of the authorization the user is being asked to approve. A grant can only be read by the user it belongs to, or by server SDK.`)
-  .requiredOption(`--grant-_id <grant-_id>`, `Grant ID made during authorization, provided to consent screen in URL search params.`)
+  .requiredOption(`--grant-id <grant-id>`, `Grant ID made during authorization, provided to consent screen in URL search params.`)
   .action(
     actionRunner(
-      async ({ grant_id }) =>
-        parse(await (await getOauth2Client()).getGrant(grant_id)),
+      async ({ grantId }) =>
+        parse(await (await getOauth2Client()).getGrant(grantId)),
     ),
   );
 
@@ -92,16 +92,16 @@ const oauth2GetGrantCommand = oauth2
 const oauth2LogoutCommand = oauth2
   .command(`logout`)
   .description(`OpenID Connect RP-Initiated Logout. Ends the user session and revokes the tokens issued to the app identified by the \`id_token_hint\`, then redirects the user to \`post_logout_redirect_uri\` when it matches a URI registered on the app.`)
-  .option(`--id-_token-_hint <id-_token-_hint>`, `ID Token previously issued to the app, used as proof of the logout request. Required to end the session; signature and issuer are validated while expiry is ignored.`)
-  .option(`--logout-_hint <logout-_hint>`, `Hint about the user that is logging out. Accepted for OIDC compatibility.`)
-  .option(`--client-_id <client-_id>`, `OAuth2 client ID. When both \`client_id\` and \`id_token_hint\` are provided, they must identify the same app.`)
-  .option(`--post-_logout-_redirect-_uri <post-_logout-_redirect-_uri>`, `URI to redirect the user to after logout. Must exactly match a URI registered in the app's \`postLogoutRedirectUris\`.`)
+  .option(`--id-token-hint <id-token-hint>`, `ID Token previously issued to the app, used as proof of the logout request. Required to end the session; signature and issuer are validated while expiry is ignored.`)
+  .option(`--logout-hint <logout-hint>`, `Hint about the user that is logging out. Accepted for OIDC compatibility.`)
+  .option(`--client-id <client-id>`, `OAuth2 client ID. When both \`client_id\` and \`id_token_hint\` are provided, they must identify the same app.`)
+  .option(`--post-logout-redirect-uri <post-logout-redirect-uri>`, `URI to redirect the user to after logout. Must exactly match a URI registered in the app's \`postLogoutRedirectUris\`.`)
   .option(`--state <state>`, `Opaque value passed back unchanged in the \`state\` query param of the post-logout redirect.`)
-  .option(`--ui-_locales <ui-_locales>`, `Preferred languages for any logout UI, as space-separated BCP47 tags. Accepted for OIDC compatibility.`)
+  .option(`--ui-locales <ui-locales>`, `Preferred languages for any logout UI, as space-separated BCP47 tags. Accepted for OIDC compatibility.`)
   .action(
     actionRunner(
-      async ({ id_token_hint, logout_hint, client_id, post_logout_redirect_uri, state, ui_locales }) =>
-        parse(await (await getOauth2Client()).logout(id_token_hint, logout_hint, client_id, post_logout_redirect_uri, state, ui_locales)),
+      async ({ idTokenHint, logoutHint, clientId, postLogoutRedirectUri, state, uiLocales }) =>
+        parse(await (await getOauth2Client()).logout(idTokenHint, logoutHint, clientId, postLogoutRedirectUri, state, uiLocales)),
     ),
   );
 
@@ -123,22 +123,22 @@ const oauth2ListOrganizationsCommand = oauth2
 const oauth2CreatePARCommand = oauth2
   .command(`create-par`)
   .description(`Store an OAuth2 authorization request server-side and receive a short-lived request_uri handle for the authorize endpoint.`)
-  .requiredOption(`--client-_id <client-_id>`, `OAuth2 client ID.`)
-  .requiredOption(`--redirect-_uri <redirect-_uri>`, `Redirect URI where visitor will be redirected after authorization, whether successful or not.`)
-  .requiredOption(`--response-_type <response-_type>`, `OAuth2 / OIDC response type.`)
+  .requiredOption(`--client-id <client-id>`, `OAuth2 client ID.`)
+  .requiredOption(`--redirect-uri <redirect-uri>`, `Redirect URI where visitor will be redirected after authorization, whether successful or not.`)
+  .requiredOption(`--response-type <response-type>`, `OAuth2 / OIDC response type.`)
   .requiredOption(`--scope <scope>`, `Space-separated OAuth2 scopes. Can include project scopes, and built-in scopes: \`openid\`, \`email\`, \`profile\`, \`phone\`.`)
   .option(`--state <state>`, `OAuth2 state. You receive this back in the redirect URI.`)
   .option(`--nonce <nonce>`, `OIDC nonce parameter to prevent replay attacks. Required when response_type includes \`id_token\`.`)
-  .option(`--code-_challenge <code-_challenge>`, `PKCE code challenge. Required when OAuth2 app is public.`)
-  .option(`--code-_challenge-_method <code-_challenge-_method>`, `PKCE code challenge method. Required when OAuth2 app is public.`)
+  .option(`--code-challenge <code-challenge>`, `PKCE code challenge. Required when OAuth2 app is public.`)
+  .option(`--code-challenge-method <code-challenge-method>`, `PKCE code challenge method. Required when OAuth2 app is public.`)
   .option(`--prompt <prompt>`, `OIDC prompt parameter for customization of consent screen. Space-separated list of: none, login, consent, select_account.`)
-  .option(`--max-_age <max-_age>`, `OIDC max_age parameter for customization of consent screen.`, parseInteger)
-  .option(`--authorization-_details <authorization-_details>`, `Rich authorization request. JSON array of objects, each with a \`type\` and project-defined fields`)
+  .option(`--max-age <max-age>`, `OIDC max_age parameter for customization of consent screen.`, parseInteger)
+  .option(`--authorization-details <authorization-details>`, `Rich authorization request. JSON array of objects, each with a \`type\` and project-defined fields`)
   .option(`--resource <resource>`, `RFC 8707 resource indicator URI or URI list. Each value must be an absolute URI without a fragment.`)
   .action(
     actionRunner(
-      async ({ client_id, redirect_uri, response_type, scope, state, nonce, code_challenge, code_challenge_method, prompt, max_age, authorization_details, resource }) =>
-        parse(await (await getOauth2Client()).createPAR(client_id, redirect_uri, response_type, scope, state, nonce, code_challenge, code_challenge_method, prompt, max_age, authorization_details, resource)),
+      async ({ clientId, redirectUri, responseType, scope, state, nonce, codeChallenge, codeChallengeMethod, prompt, maxAge, authorizationDetails, resource }) =>
+        parse(await (await getOauth2Client()).createPAR(clientId, redirectUri, responseType, scope, state, nonce, codeChallenge, codeChallengeMethod, prompt, maxAge, authorizationDetails, resource)),
     ),
   );
 
@@ -160,11 +160,11 @@ const oauth2ListProjectsCommand = oauth2
 const oauth2RejectCommand = oauth2
   .command(`reject`)
   .description(`Reject an OAuth2 grant when the user denies consent. Returns the \`redirectUrl\` the end user should be sent to with an \`access_denied\` error. You can pass Accept header of \`application/json\` to receive a JSON response instead of a redirect.`)
-  .requiredOption(`--grant-_id <grant-_id>`, `Grant ID made during authorization, provided to consent screen in URL search params.`)
+  .requiredOption(`--grant-id <grant-id>`, `Grant ID made during authorization, provided to consent screen in URL search params.`)
   .action(
     actionRunner(
-      async ({ grant_id }) =>
-        parse(await (await getOauth2Client()).reject(grant_id)),
+      async ({ grantId }) =>
+        parse(await (await getOauth2Client()).reject(grantId)),
     ),
   );
 
@@ -173,13 +173,13 @@ const oauth2RevokeCommand = oauth2
   .command(`revoke`)
   .description(`Revoke an OAuth2 access token or refresh token.`)
   .requiredOption(`--token <token>`, `The access or refresh token to revoke.`)
-  .option(`--token-_type-_hint <token-_type-_hint>`, `Type of token to revoke (access_token or refresh_token).`)
-  .option(`--client-_id <client-_id>`, `OAuth2 client ID.`)
-  .option(`--client-_secret <client-_secret>`, `OAuth2 client secret. Required for confidential apps; omitted for public apps.`)
+  .option(`--token-type-hint <token-type-hint>`, `Type of token to revoke (access_token or refresh_token).`)
+  .option(`--client-id <client-id>`, `OAuth2 client ID.`)
+  .option(`--client-secret <client-secret>`, `OAuth2 client secret. Required for confidential apps; omitted for public apps.`)
   .action(
     actionRunner(
-      async ({ token, token_type_hint, client_id, client_secret }) =>
-        parse(await (await getOauth2Client()).revoke(token, token_type_hint, client_id, client_secret)),
+      async ({ token, tokenTypeHint, clientId, clientSecret }) =>
+        parse(await (await getOauth2Client()).revoke(token, tokenTypeHint, clientId, clientSecret)),
     ),
   );
 
@@ -187,19 +187,19 @@ const oauth2RevokeCommand = oauth2
 const oauth2CreateTokenCommand = oauth2
   .command(`create-token`)
   .description(`Exchange an OAuth2 authorization code, refresh token, or device code for access and refresh tokens.`)
-  .requiredOption(`--grant-_type <grant-_type>`, `OAuth2 grant type. Can be one of: \`authorization_code\`, \`refresh_token\`, \`urn:ietf:params:oauth:grant-type:device_code\`.`)
+  .requiredOption(`--grant-type <grant-type>`, `OAuth2 grant type. Can be one of: \`authorization_code\`, \`refresh_token\`, \`urn:ietf:params:oauth:grant-type:device_code\`.`)
   .option(`--code <code>`, `Authorization code to be exchanged for access and refresh tokens. Required for \`authorization_code\` grant type.`)
-  .option(`--refresh-_token <refresh-_token>`, `Refresh token to be exchanged for a new access and refresh tokens. Required for \`refresh_token\` grant type.`)
-  .option(`--device-_code <device-_code>`, `Device code obtained from the device authorization endpoint. Required for \`urn:ietf:params:oauth:grant-type:device_code\` grant type.`)
-  .option(`--client-_id <client-_id>`, `OAuth2 client ID.`)
-  .option(`--client-_secret <client-_secret>`, `OAuth2 client secret. Required for confidential apps.`)
-  .option(`--code-_verifier <code-_verifier>`, `PKCE code verifier. Required for public apps.`)
-  .option(`--redirect-_uri <redirect-_uri>`, `Redirect URI. Required for \`authorization_code\` grant type.`)
+  .option(`--refresh-token <refresh-token>`, `Refresh token to be exchanged for a new access and refresh tokens. Required for \`refresh_token\` grant type.`)
+  .option(`--device-code <device-code>`, `Device code obtained from the device authorization endpoint. Required for \`urn:ietf:params:oauth:grant-type:device_code\` grant type.`)
+  .option(`--client-id <client-id>`, `OAuth2 client ID.`)
+  .option(`--client-secret <client-secret>`, `OAuth2 client secret. Required for confidential apps.`)
+  .option(`--code-verifier <code-verifier>`, `PKCE code verifier. Required for public apps.`)
+  .option(`--redirect-uri <redirect-uri>`, `Redirect URI. Required for \`authorization_code\` grant type.`)
   .option(`--resource <resource>`, `RFC 8707 resource indicator URI or URI list. Each value must be an absolute URI without a fragment.`)
   .action(
     actionRunner(
-      async ({ grant_type, code, refresh_token, device_code, client_id, client_secret, code_verifier, redirect_uri, resource }) =>
-        parse(await (await getOauth2Client()).createToken(grant_type, code, refresh_token, device_code, client_id, client_secret, code_verifier, redirect_uri, resource)),
+      async ({ grantType, code, refreshToken, deviceCode, clientId, clientSecret, codeVerifier, redirectUri, resource }) =>
+        parse(await (await getOauth2Client()).createToken(grantType, code, refreshToken, deviceCode, clientId, clientSecret, codeVerifier, redirectUri, resource)),
     ),
   );
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,7 +1,7 @@
 // SDK
 export const SDK_TITLE = 'Appwrite';
 export const SDK_TITLE_LOWER = 'appwrite';
-export const SDK_VERSION = '22.6.0';
+export const SDK_VERSION = '22.7.0';
 export const SDK_NAME = 'Command Line';
 export const SDK_PLATFORM = 'console';
 export const SDK_LANGUAGE = 'cli';

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,7 +1,7 @@
 // SDK
 export const SDK_TITLE = 'Appwrite';
 export const SDK_TITLE_LOWER = 'appwrite';
-export const SDK_VERSION = '22.7.0';
+export const SDK_VERSION = '22.6.1';
 export const SDK_NAME = 'Command Line';
 export const SDK_PLATFORM = 'console';
 export const SDK_LANGUAGE = 'cli';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appwrite-cli",
-  "version": "22.6.0",
+  "version": "22.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "appwrite-cli",
-      "version": "22.6.0",
+      "version": "22.7.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@appwrite.io/console": "15.3.0",
@@ -49,6 +49,12 @@
         "tsx": "^4.21.0",
         "typescript": "^5.3.3",
         "typescript-eslint": "^8.0.0"
+      },
+      "overrides": {
+        "phin": "3.7.1",
+        "@xmldom/xmldom": "^0.9.10",
+        "tmp": "^0.2.6",
+        "esbuild": "^0.28.1"
       }
     },
     "node_modules/@appwrite.io/console": {
@@ -1953,6 +1959,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1968,6 +1977,9 @@
       "integrity": "sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1985,6 +1997,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2001,6 +2016,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2016,6 +2034,9 @@
       "integrity": "sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5029,9 +5050,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.9.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
-      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appwrite-cli",
-  "version": "22.7.0",
+  "version": "22.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "appwrite-cli",
-      "version": "22.7.0",
+      "version": "22.6.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@appwrite.io/console": "15.3.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "homepage": "https://appwrite.io/support",
   "description": "Appwrite is an open-source self-hosted backend server that abstracts and simplifies complex and repetitive development tasks behind a very simple REST API",
-  "version": "22.6.0",
+  "version": "22.7.0",
   "license": "BSD-3-Clause",
   "main": "dist/index.cjs",
   "module": "dist/index.js",
@@ -79,20 +79,20 @@
     "esbuild": "^0.28.1"
   },
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^8.0.0",
+    "@typescript-eslint/parser": "^8.0.0",
     "@types/bun": "^1.3.5",
+    "eslint": "^9.0.0",
+    "eslint-plugin-unused-imports": "^4.0.0",
+    "typescript-eslint": "^8.0.0",
     "@types/cli-progress": "^3.11.5",
     "@types/inquirer": "^8.2.10",
     "@types/json-bigint": "^1.0.4",
     "@types/node": "^18.19.0",
     "@types/tar": "^6.1.13",
-    "@typescript-eslint/eslint-plugin": "^8.0.0",
-    "@typescript-eslint/parser": "^8.0.0",
     "esbuild": "^0.28.1",
-    "eslint": "^9.0.0",
-    "eslint-plugin-unused-imports": "^4.0.0",
     "prettier": "^3.7.4",
     "tsx": "^4.21.0",
-    "typescript": "^5.3.3",
-    "typescript-eslint": "^8.0.0"
+    "typescript": "^5.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "homepage": "https://appwrite.io/support",
   "description": "Appwrite is an open-source self-hosted backend server that abstracts and simplifies complex and repetitive development tasks behind a very simple REST API",
-  "version": "22.7.0",
+  "version": "22.6.1",
   "license": "BSD-3-Clause",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/scoop/appwrite.config.json
+++ b/scoop/appwrite.config.json
@@ -1,12 +1,12 @@
 {
 	"$schema": "https://raw.githubusercontent.com/ScoopInstaller/Scoop/master/schema.json",
-	"version": "22.7.0",
+	"version": "22.6.1",
 	"description": "The Appwrite CLI is a command-line application that allows you to interact with Appwrite and perform server-side tasks using your terminal.",
 	"homepage": "https://github.com/appwrite/sdk-for-cli",
 	"license": "BSD-3-Clause",
 	"architecture": {
 		"64bit": {
-			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/22.7.0/appwrite-cli-win-x64.exe",
+			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/22.6.1/appwrite-cli-win-x64.exe",
 			"bin": [
 				[
 					"appwrite-cli-win-x64.exe",
@@ -15,7 +15,7 @@
 			]
 		},
 		"arm64": {
-			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/22.7.0/appwrite-cli-win-arm64.exe",
+			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/22.6.1/appwrite-cli-win-arm64.exe",
 			"bin": [
 				[
 					"appwrite-cli-win-arm64.exe",

--- a/scoop/appwrite.config.json
+++ b/scoop/appwrite.config.json
@@ -1,12 +1,12 @@
 {
 	"$schema": "https://raw.githubusercontent.com/ScoopInstaller/Scoop/master/schema.json",
-	"version": "22.6.0",
+	"version": "22.7.0",
 	"description": "The Appwrite CLI is a command-line application that allows you to interact with Appwrite and perform server-side tasks using your terminal.",
 	"homepage": "https://github.com/appwrite/sdk-for-cli",
 	"license": "BSD-3-Clause",
 	"architecture": {
 		"64bit": {
-			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/22.6.0/appwrite-cli-win-x64.exe",
+			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/22.7.0/appwrite-cli-win-x64.exe",
 			"bin": [
 				[
 					"appwrite-cli-win-x64.exe",
@@ -15,7 +15,7 @@
 			]
 		},
 		"arm64": {
-			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/22.6.0/appwrite-cli-win-arm64.exe",
+			"url": "https://github.com/appwrite/sdk-for-cli/releases/download/22.7.0/appwrite-cli-win-arm64.exe",
 			"bin": [
 				[
 					"appwrite-cli-win-arm64.exe",


### PR DESCRIPTION
This PR contains updates to the SDK for version 22.6.1, generated with sdk-generator 2.4.8.

## What's Changed

* Fixed: snake_case parameters now map to proper kebab-case flags: `oauth2` commands use `--client-id`, `--redirect-uri`, `--response-type`, `--request-uri`, `--code-challenge`, `--max-age` instead of the malformed `--client-_id` style names

Note: this renames the OAuth2 command flags shipped in 22.5.0/22.6.0 (via [appwrite/sdk-generator#1658](https://github.com/appwrite/sdk-generator/pull/1658)). The `@appwrite.io/console@15.3.0` pin now comes from the generator template directly ([appwrite/sdk-generator#1653](https://github.com/appwrite/sdk-generator/pull/1653)).