### PR TITLE
fix: normalize package-lock.json to npm 11.10.0 output for publish audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,12 +49,6 @@
         "tsx": "^4.21.0",
         "typescript": "^5.3.3",
         "typescript-eslint": "^8.0.0"
-      },
-      "overrides": {
-        "phin": "3.7.1",
-        "@xmldom/xmldom": "^0.9.10",
-        "tmp": "^0.2.6",
-        "esbuild": "^0.28.1"
       }
     },
     "node_modules/@appwrite.io/console": {
@@ -1959,9 +1953,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1977,9 +1968,6 @@
       "integrity": "sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1997,9 +1985,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2016,9 +2001,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2034,9 +2016,6 @@
       "integrity": "sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
The 22.6.1 publish run failed at the `Audit npm dependencies` step: the committed `package-lock.json` came from the sdk-generator template (generated with npm 11.16.0, which writes `libc` fields and an `overrides` block in `packages[""]`), but the workflow pins npm 11.10.0, whose `npm install --package-lock-only` rewrite drops those fields — so `git diff --exit-code package-lock.json` fails.

This commits the npm 11.10.0-normalized lock, which is verified to be a fixed point of the audit's rewrite (a second `--package-lock-only` run produces zero diff). `npm ci && npm run build` verified working with the normalized lock.

Follow-up needed in appwrite/sdk-generator: regenerate `package-lock.json.twig` with npm 11.10.0 (or align the workflow pin and `update-lockfiles.sh` on one npm version), otherwise the next SDK regeneration reintroduces the drift.