### PR TITLE
fix: audit the committed lockfile without regenerating it

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -144,11 +144,10 @@ jobs:
 
       - name: Audit npm dependencies
         run: |
-          # CLI builds with Bun, but npm audit reads package-lock.json.
-          # update-lockfiles.sh updates both lockfiles; this catches npm lock drift.
-          npm install --package-lock-only --ignore-scripts
-          git diff --exit-code package-lock.json
-          npm audit --audit-level=high --omit=dev
+          # The committed package-lock.json is generated from sdk-generator's
+          # lockfile template (the single source of truth) — never rewrite it
+          # here; different npm versions emit different lockfile metadata.
+          npm audit --package-lock-only --audit-level=high --omit=dev
 
       - name: Publish
         run: npm publish --provenance --access public --tag ${{ steps.release_tag.outputs.tag }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -143,11 +143,7 @@ jobs:
           fi
 
       - name: Audit npm dependencies
-        run: |
-          # The committed package-lock.json is generated from sdk-generator's
-          # lockfile template (the single source of truth) — never rewrite it
-          # here; different npm versions emit different lockfile metadata.
-          npm audit --package-lock-only --audit-level=high --omit=dev
+        run: npm audit --package-lock-only --audit-level=high --omit=dev
 
       - name: Publish
         run: npm publish --provenance --access public --tag ${{ steps.release_tag.outputs.tag }}


### PR DESCRIPTION
The publish workflow's audit step rewrote `package-lock.json` with CI's pinned npm and failed on any diff. That check asserts CI's npm version can byte-reproduce the committed lock — but the lock is generated from sdk-generator's `package-lock.json.twig` (the single source of truth), and npm versions differ in the lockfile metadata they emit (`libc` fields, `overrides` placement). This is what blocked the 22.6.1 release until the lock was hand-normalized in #339.

The step now only runs the vulnerability scan against the committed lock:

```yaml
npm audit --package-lock-only --audit-level=high --omit=dev
```

`--package-lock-only` reads the lockfile directly (no install, no rewrite). Verified locally with npm 11.10.0: audit passes and the lock is untouched.

Lockfile integrity is still covered — Build Validation runs `npm ci`, which fails if the lock and `package.json` are out of sync.