### PR TITLE
fix(release): install ldid from upstream, not from apt

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,11 +48,23 @@ jobs:
 
       # Linux runners have no codesign, so ad-hoc signing the darwin builds
       # falls back to ldid.
+      # No apt package exists for ldid on any Ubuntu release, so this is the
+      # upstream prebuilt binary, pinned and checksummed: the runner downloads
+      # the thing that signs every macOS build, and a swapped artifact would
+      # otherwise be signing them.
       - name: Install ldid
+        env:
+          LDID_VERSION: v2.1.5-procursus7
+          LDID_SHA256: 4b8862b2fefa2cd7fa8f88cb0310779619aeaa8c72d6aff22f019b470f2fa99a
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y ldid
+
+          curl -fsSL -o /tmp/ldid \
+            "https://github.com/ProcursusTeam/ldid/releases/download/${LDID_VERSION}/ldid_linux_x86_64"
+          echo "${LDID_SHA256}  /tmp/ldid" | sha256sum --check --strict
+
+          sudo install -m 0755 /tmp/ldid /usr/local/bin/ldid
+          ldid -V
 
       - name: Build
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0


### PR DESCRIPTION
The `26.0.0-rc.1` publish run failed at its first working step:

```
sudo apt-get install -y ldid
E: Unable to locate package ldid
```

No apt package named `ldid` exists on any Ubuntu release. `publish.yml` runs
only on `release: published`, so nothing had ever executed this step before.

`scripts/adhoc-sign.sh` exits 1 without codesign or ldid, so goreleaser's
post-build hook failed and the release produced no binaries at all. That is the
cheap outcome: the run died before uploading assets or publishing to npm, so
26.0.0-rc.1 is still reusable.

Had signing been skipped rather than failed, `install.sh` would have rejected
every darwin download -- it runs `codesign -dv` and aborts on an unsigned
binary, and the Go linker signs darwin/arm64 but not amd64, so Intel Macs would
have broken while Apple Silicon worked.

Now the upstream prebuilt from ProcursusTeam/ldid, pinned by version and
SHA-256, since this binary signs every macOS artifact the release ships.

Generated from appwrite/sdk-generator 2.10.3 (appwrite/sdk-generator#1750). The
regenerated tree differs from `master` in this file alone.

## Verification

The step was run in `ubuntu:24.04`, then used to sign a real darwin/amd64 build,
checking the property `install.sh` tests -- the exit code of `codesign -dv`:

| Artifact | `codesign -dv` |
|----------|----------------|
| darwin/amd64 as the Go linker leaves it | exit **1**, "code object is not signed at all" |
| the same binary after `ldid -S` | exit **0**, CodeDirectory embedded |
