### PR TITLE
fix(release): install ldid from upstream, and keep updates on their channel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,7 +64,10 @@ jobs:
           echo "${LDID_SHA256}  /tmp/ldid" | sha256sum --check --strict
 
           sudo install -m 0755 /tmp/ldid /usr/local/bin/ldid
-          ldid -V
+          # The gate adhoc-sign.sh itself uses. ldid has no flag that exits 0 --
+          # -V, -v and --version all print usage and exit 1 -- so a version
+          # check here fails the step it is meant to be reassuring about.
+          command -v ldid
 
       - name: Build
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 * Breaking: Removed usage and log commands on `presences`, `project`, `users`, and `teams`
 * Added: Homebrew, scoop, and `curl | bash` installs alongside npm
 * Added: A per-platform npm package, so installing no longer downloads a binary afterwards
+* Added: `update` follows the prerelease channel, so a release candidate moves to the next candidate
+* Added: `update` refuses to install an older version unless `--force` is passed
 * Updated: Startup is around 9.5ms, down from around 173ms
 
 ## 25.1.0

--- a/internal/app/install.go
+++ b/internal/app/install.go
@@ -140,7 +140,7 @@ func HomebrewFormula() string {
 	return ""
 }
 
-// NPMRegistryURL is where the newest published version is looked up.
+// NPMRegistryURL is where the newest stable version is looked up.
 //
 // Homebrew installs are updated through brew, but the
 // version published to npm is the same release, so one source answers for both
@@ -155,6 +155,10 @@ func HomebrewFormula() string {
 // `latest` before picking a number.
 const NPMRegistryURL = "https://registry.npmjs.org/" + NPMPackageName + "/latest"
 
+// NPMPrereleaseRegistryURL follows the release candidates published under the
+// next dist-tag. Stable builds never query it.
+const NPMPrereleaseRegistryURL = "https://registry.npmjs.org/" + NPMPackageName + "/next"
+
 // UpdateChecker builds the once-a-day version check, or nil when there is
 // nowhere to cache its answer.
 func UpdateChecker() *update.Checker {
@@ -164,7 +168,8 @@ func UpdateChecker() *update.Checker {
 	}
 
 	return &update.Checker{
-		RegistryURL: NPMRegistryURL,
+		RegistryURL:           NPMRegistryURL,
+		PrereleaseRegistryURL: NPMPrereleaseRegistryURL,
 		// Beside the preferences, which is already the directory this CLI owns.
 		CachePath: filepath.Join(home, "."+ExecutableName, "update-check.json"),
 		Current:   Version,

--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/appwrite/sdk-for-cli/internal/app"
 	"github.com/appwrite/sdk-for-cli/internal/output"
+	"github.com/appwrite/sdk-for-cli/internal/update"
 	"github.com/spf13/cobra"
 )
 
@@ -52,6 +53,38 @@ func resolveReleaseVersion() string {
 	return checker.Explicit()
 }
 
+// resolveStableReleaseVersion is the version a stable-only package manager
+// can install, regardless of the running binary's channel.
+func resolveStableReleaseVersion() string {
+	checker := app.UpdateChecker()
+	if checker == nil {
+		return ""
+	}
+
+	return checker.ExplicitStable()
+}
+
+// validateUpdateVersion stops an ordinary update from reinstalling the same
+// release or walking backwards. --force remains the explicit escape hatch.
+func validateUpdateVersion(current, target string, force bool) error {
+	if force {
+		return nil
+	}
+
+	switch update.Compare(current, target) {
+	case 0:
+		return fmt.Errorf(
+			"%s is already at version %s. Re-run with --force to reinstall it",
+			app.ExecutableName, current)
+	case 1:
+		return fmt.Errorf(
+			"refusing to downgrade %s from %s to %s. Re-run with --force to continue",
+			app.ExecutableName, current, target)
+	}
+
+	return nil
+}
+
 func newUpdateCommand() *cobra.Command {
 	var (
 		force  bool
@@ -75,17 +108,32 @@ func newUpdateCommand() *cobra.Command {
 
 			switch method {
 			case app.InstallNPM:
+				version := resolveReleaseVersion()
+				if version == "" {
+					return unresolvedVersionError()
+				}
+				if err := validateUpdateVersion(app.Version, version, force); err != nil {
+					return err
+				}
 				command.Printf("Updating via npm...\n")
 
-				return runUpdater(command, "npm", "install", "-g", app.NPMPackageName+"@latest")
+				return runUpdater(command, version, "npm", "install", "-g",
+					app.NPMPackageName+"@"+version)
 			case app.InstallHomebrew:
+				version := resolveStableReleaseVersion()
+				if version == "" {
+					return unresolvedVersionError()
+				}
+				if err := validateUpdateVersion(app.Version, version, force); err != nil {
+					return err
+				}
 				formula := app.HomebrewFormula()
 				if formula == "" {
 					formula = app.ExecutableName
 				}
 				command.Printf("Updating via Homebrew (%s)...\n", formula)
 
-				return runUpdater(command, "brew", "upgrade", formula)
+				return runUpdater(command, version, "brew", "upgrade", formula)
 			case app.InstallStandalone:
 				return updateStandalone(command, force)
 			}
@@ -98,7 +146,7 @@ func newUpdateCommand() *cobra.Command {
 		},
 	}
 	command.Flags().BoolVarP(&force, "force", "f", false,
-		"Replace the binary even if its location looks unexpected.")
+		"Update even if the target is not newer or the binary location looks unexpected.")
 	command.Flags().BoolVar(&manual, "manual", false,
 		"Show manual update instructions instead of auto-updating")
 
@@ -113,6 +161,8 @@ func newUpdateCommand() *cobra.Command {
 // rather than an attempt that fails.
 func printManualInstructions(command *cobra.Command) {
 	out := command.OutOrStdout()
+	version := resolveReleaseVersion()
+	npmVersion := manualNPMVersion(app.Version, version)
 
 	formula := app.HomebrewFormula()
 	if formula == "" {
@@ -123,18 +173,23 @@ func printManualInstructions(command *cobra.Command) {
 	fmt.Fprintln(out)
 
 	output.Log(out, "Option 1: NPM")
-	fmt.Fprintf(out, "  npm install -g %s@latest\n\n", app.NPMPackageName)
+	fmt.Fprintf(out, "  npm install -g %s@%s\n\n", app.NPMPackageName, npmVersion)
 
 	output.Log(out, "Option 2: Homebrew")
-	fmt.Fprintf(out, "  brew upgrade %s\n\n", formula)
+	if update.IsPrerelease(app.Version) {
+		fmt.Fprintln(out, "  Homebrew publishes stable releases only; use npm or the standalone binary.")
+		fmt.Fprintln(out)
+	} else {
+		fmt.Fprintf(out, "  brew upgrade %s\n\n", formula)
+	}
 
 	// Only where a downloaded binary can be swapped in from a shell; the
 	// Windows equivalent is the installer, not a curl one-liner.
-	if runtime.GOOS != "windows" {
+	if runtime.GOOS != "windows" && version != "" {
 		if asset, err := app.ReleaseAssetName(); err == nil {
 			output.Log(out, "Option 3: Install Script / Standalone Binary")
 			fmt.Fprintf(out, "  curl -fsSL %s -o %s\n",
-				releaseAssetURL(resolveReleaseVersion(), asset),
+				releaseAssetURL(version, asset),
 				filepath.Join(os.TempDir(), app.ExecutableName))
 			fmt.Fprintln(out)
 		}
@@ -143,8 +198,19 @@ func printManualInstructions(command *cobra.Command) {
 	output.Hint(out, "Download the latest release manually at: %s", releasesPageURL)
 }
 
+func manualNPMVersion(current, resolved string) string {
+	if resolved != "" {
+		return resolved
+	}
+	if update.IsPrerelease(current) {
+		return "next"
+	}
+
+	return "latest"
+}
+
 // runUpdater shells out to the package manager that owns this install.
-func runUpdater(command *cobra.Command, name string, args ...string) error {
+func runUpdater(command *cobra.Command, version, name string, args ...string) error {
 	binary, err := exec.LookPath(name)
 	if err != nil {
 		return fmt.Errorf("%s is not on PATH, so the CLI cannot update itself: %w", name, err)
@@ -158,7 +224,7 @@ func runUpdater(command *cobra.Command, name string, args ...string) error {
 		return fmt.Errorf("%s failed: %w", name, err)
 	}
 
-	command.Println("Updated to the latest version.")
+	command.Printf("Updated to version %s.\n", version)
 
 	return nil
 }
@@ -171,6 +237,13 @@ func runUpdater(command *cobra.Command, name string, args ...string) error {
 func updateStandalone(command *cobra.Command, force bool) error {
 	asset, err := app.ReleaseAssetName()
 	if err != nil {
+		return err
+	}
+	version := resolveReleaseVersion()
+	if version == "" {
+		return unresolvedVersionError()
+	}
+	if err := validateUpdateVersion(app.Version, version, force); err != nil {
 		return err
 	}
 
@@ -192,12 +265,6 @@ func updateStandalone(command *cobra.Command, force bool) error {
 	directory := filepath.Dir(target)
 	if err := checkWritable(directory); err != nil {
 		return fmt.Errorf("cannot write to %s: %w. Re-run with elevated permissions", directory, err)
-	}
-
-	version := resolveReleaseVersion()
-	if version == "" {
-		return fmt.Errorf(
-			"cannot determine the version to install. Download it manually at %s", releasesPageURL)
 	}
 
 	command.Printf("Downloading %s %s...\n", asset, version)
@@ -248,6 +315,11 @@ func updateStandalone(command *cobra.Command, force bool) error {
 	command.Printf("Updated %s.\n", target)
 
 	return nil
+}
+
+func unresolvedVersionError() error {
+	return fmt.Errorf(
+		"cannot determine the version to install. Download it manually at %s", releasesPageURL)
 }
 
 // checksumsAsset is the digest manifest goreleaser publishes beside the

--- a/internal/cmd/updateasset_test.go
+++ b/internal/cmd/updateasset_test.go
@@ -48,6 +48,29 @@ func TestReleaseAssetURLKeepsTheAssetName(t *testing.T) {
 	}
 }
 
+func TestUpdateVersionGuard(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		current string
+		target  string
+		force   bool
+		wantErr bool
+	}{
+		{name: "newer candidate", current: "26.0.0-rc.1", target: "26.0.0-rc.2"},
+		{name: "same version", current: "26.0.0-rc.2", target: "26.0.0-rc.2", wantErr: true},
+		{name: "downgrade", current: "26.0.0-rc.1", target: "25.1.0", wantErr: true},
+		{name: "forced downgrade", current: "26.0.0-rc.1", target: "25.1.0", force: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateUpdateVersion(test.current, test.target, test.force)
+			if (err != nil) != test.wantErr {
+				t.Errorf("validateUpdateVersion(%q, %q, %t) error = %v, wantErr %t",
+					test.current, test.target, test.force, err, test.wantErr)
+			}
+		})
+	}
+}
+
 // A real goreleaser manifest: two spaces between digest and filename, one line
 // per asset, Windows assets carrying their extension.
 const checksumsManifest = `d1e8a70b5ccab1dc2f56bbf7e99f064a2fc6dc2d3c9d4b1e0a7f2c3b4a596877  appwrite-cli-darwin-arm64

--- a/internal/update/check.go
+++ b/internal/update/check.go
@@ -29,8 +29,8 @@ const (
 	// CLI's whole startup budget, so it gets one.
 	startupTimeout = time.Second
 
-	// explicitTimeout is for `--version`, where the user is waiting for an
-	// answer about versions and a slow reply beats no reply.
+	// explicitTimeout is for `update`, where the user is waiting for an answer
+	// about versions and a slow reply beats no reply.
 	explicitTimeout = 5 * time.Second
 
 	// DisableEnvironmentVariable turns the check off entirely.
@@ -41,6 +41,8 @@ const (
 type Checker struct {
 	// RegistryURL is the npm endpoint for the package's latest release.
 	RegistryURL string
+	// PrereleaseRegistryURL is the npm endpoint for the package's next release.
+	PrereleaseRegistryURL string
 	// CachePath is where the last answer is remembered.
 	CachePath string
 	// Current is the running version.
@@ -56,9 +58,16 @@ type Checker struct {
 // printed on every single command -- the lookup was cached, the telling was
 // not -- which is nagging rather than informing.
 type cache struct {
-	CheckedAt  string `json:"checkedAt"`
-	Latest     string `json:"latest"`
-	NotifiedAt string `json:"notifiedAt,omitempty"`
+	CheckedAt         string `json:"checkedAt"`
+	Latest            string `json:"latest"`
+	Next              string `json:"next,omitempty"`
+	PrereleaseChecked bool   `json:"prereleaseChecked,omitempty"`
+	NotifiedAt        string `json:"notifiedAt,omitempty"`
+}
+
+type releases struct {
+	Latest string
+	Next   string
 }
 
 // Latest returns the newest published version, from cache when it is fresh.
@@ -66,41 +75,63 @@ type cache struct {
 // An error is never worth surfacing: a failed update check must not change what
 // the command was asked to do. Callers get "" and carry on.
 func (c *Checker) Latest(timeout time.Duration) string {
-	latest, _ := c.resolve(timeout)
+	includePrerelease := IsPrerelease(c.Current) && c.PrereleaseRegistryURL != ""
+	available, _ := c.resolve(timeout, includePrerelease, true)
 
-	return latest
+	return available.newest(includePrerelease)
+}
+
+// Stable returns the newest stable release, even when Current is a prerelease.
+func (c *Checker) Stable(timeout time.Duration) string {
+	available, _ := c.resolve(timeout, false, true)
+
+	return available.Latest
 }
 
 // resolve returns the newest version and the cache entry it came from,
 // refreshing the entry when it is stale.
-func (c *Checker) resolve(timeout time.Duration) (string, cache) {
+func (c *Checker) resolve(
+	timeout time.Duration,
+	includePrerelease bool,
+	useFreshCache bool,
+) (releases, cache) {
 	if os.Getenv(DisableEnvironmentVariable) != "" {
-		return "", cache{}
+		return releases{}, cache{}
 	}
 
 	stored, fresh := c.read()
-	if fresh {
-		return stored.Latest, stored
+	if useFreshCache && fresh && (!includePrerelease || stored.PrereleaseChecked) {
+		return stored.releases(), stored
 	}
 
-	fetched := c.fetch(timeout)
-	if fetched == "" {
+	fetched := c.fetch(timeout, includePrerelease)
+	if fetched.Latest == "" && fetched.Next == "" {
 		// Stale beats nothing: a version from yesterday still answers the
 		// question, and the network may be down for a while.
-		return stored.Latest, stored
+		return stored.releases(), stored
+	}
+	if fetched.Latest != "" {
+		stored.Latest = fetched.Latest
+	}
+	if fetched.Next != "" {
+		stored.Next = fetched.Next
 	}
 
-	stored.Latest = fetched
-	stored.CheckedAt = c.now().UTC().Format(time.RFC3339)
+	stored.PrereleaseChecked = includePrerelease && fetched.Next != ""
+	if fetched.Latest != "" {
+		stored.CheckedAt = c.now().UTC().Format(time.RFC3339)
+	}
 	c.write(stored)
 
-	return fetched, stored
+	return stored.releases(), stored
 }
 
 // UpdateAvailable reports the newer version, or "" when there is none or when
 // the user has already been told within the interval.
 func (c *Checker) UpdateAvailable() string {
-	latest, stored := c.resolve(startupTimeout)
+	includePrerelease := IsPrerelease(c.Current) && c.PrereleaseRegistryURL != ""
+	available, stored := c.resolve(startupTimeout, includePrerelease, true)
+	latest := available.newest(includePrerelease)
 	if latest == "" || Compare(c.Current, latest) >= 0 {
 		return ""
 	}
@@ -115,9 +146,37 @@ func (c *Checker) UpdateAvailable() string {
 	return latest
 }
 
-// Explicit is the `--version` path: a longer timeout, and the answer either
-// way rather than only when an update exists.
-func (c *Checker) Explicit() string { return c.Latest(explicitTimeout) }
+// Explicit refreshes the registry with a longer timeout. A user who asked to
+// update should see a release published since the background cache was filled.
+func (c *Checker) Explicit() string {
+	includePrerelease := IsPrerelease(c.Current) && c.PrereleaseRegistryURL != ""
+	available, _ := c.resolve(explicitTimeout, includePrerelease, false)
+
+	return available.newest(includePrerelease)
+}
+
+// ExplicitStable is the stable-only answer used by package managers that do
+// not publish prereleases.
+func (c *Checker) ExplicitStable() string {
+	available, _ := c.resolve(explicitTimeout, false, false)
+
+	return available.Latest
+}
+
+func (entry cache) releases() releases {
+	return releases{Latest: entry.Latest, Next: entry.Next}
+}
+
+func (available releases) newest(includePrerelease bool) string {
+	if !includePrerelease || available.Next == "" {
+		return available.Latest
+	}
+	if available.Latest == "" || Compare(available.Latest, available.Next) < 0 {
+		return available.Next
+	}
+
+	return available.Latest
+}
 
 func (c *Checker) read() (cache, bool) {
 	stored := cache{}
@@ -168,15 +227,59 @@ func (c *Checker) write(entry cache) {
 	_ = os.WriteFile(c.CachePath, contents, 0o600)
 }
 
-func (c *Checker) fetch(timeout time.Duration) string {
+func (c *Checker) fetch(timeout time.Duration, includePrerelease bool) releases {
 	if c.RegistryURL == "" {
-		return ""
+		return releases{}
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, c.RegistryURL, nil)
+	type result struct {
+		prerelease bool
+		version    string
+	}
+
+	urls := []struct {
+		prerelease bool
+		url        string
+	}{{url: c.RegistryURL}}
+	if includePrerelease && c.PrereleaseRegistryURL != "" {
+		urls = append(urls, struct {
+			prerelease bool
+			url        string
+		}{prerelease: true, url: c.PrereleaseRegistryURL})
+	}
+
+	results := make(chan result, len(urls))
+	for _, endpoint := range urls {
+		go func() {
+			results <- result{
+				prerelease: endpoint.prerelease,
+				version:    fetch(ctx, endpoint.url),
+			}
+		}()
+	}
+
+	available := releases{}
+	for range urls {
+		select {
+		case fetched := <-results:
+			if fetched.prerelease {
+				available.Next = fetched.version
+			} else {
+				available.Latest = fetched.version
+			}
+		case <-ctx.Done():
+			return available
+		}
+	}
+
+	return available
+}
+
+func fetch(ctx context.Context, url string) string {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return ""
 	}
@@ -250,6 +353,9 @@ func Compare(a, b string) int {
 
 	return 0
 }
+
+// IsPrerelease reports whether a semantic version carries a prerelease suffix.
+func IsPrerelease(version string) bool { return prerelease(version) != "" }
 
 func isDevelopment(version string) bool {
 	trimmed := strings.TrimSpace(version)

--- a/internal/update/check_test.go
+++ b/internal/update/check_test.go
@@ -27,6 +27,74 @@ func TestANewerVersionIsReported(t *testing.T) {
 	}
 }
 
+func TestExplicitReleaseChannelSelection(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		current      string
+		latest       string
+		next         string
+		stableOnly   bool
+		want         string
+		wantNextGets int
+	}{
+		{name: "stable ignores next", current: "1.0.0", latest: "2.0.0", next: "3.0.0-rc.1", want: "2.0.0"},
+		{name: "candidate follows next", current: "26.0.0-rc.1", latest: "25.1.0", next: "26.0.0-rc.2", want: "26.0.0-rc.2", wantNextGets: 1},
+		{name: "final outranks candidate", current: "26.0.0-rc.1", latest: "26.0.0", next: "26.0.0-rc.2", want: "26.0.0", wantNextGets: 1},
+		{name: "next survives latest failure", current: "26.0.0-rc.1", next: "26.0.0-rc.2", want: "26.0.0-rc.2", wantNextGets: 1},
+		{name: "stable-only package manager", current: "26.0.0-rc.1", latest: "25.1.0", next: "26.0.0-rc.2", stableOnly: true, want: "25.1.0"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			nextGets := 0
+			checker := &Checker{
+				RegistryURL:           registry(t, registryPayload(test.latest), nil),
+				PrereleaseRegistryURL: registry(t, registryPayload(test.next), &nextGets),
+				CachePath:             filepath.Join(t.TempDir(), "update-check.json"),
+				Current:               test.current,
+			}
+
+			var got string
+			if test.stableOnly {
+				got = checker.ExplicitStable()
+			} else {
+				got = checker.Explicit()
+			}
+			if got != test.want {
+				t.Errorf("resolved %q, want %q", got, test.want)
+			}
+			if nextGets != test.wantNextGets {
+				t.Errorf("next requests = %d, want %d", nextGets, test.wantNextGets)
+			}
+		})
+	}
+}
+
+func TestAStableCacheDoesNotMaskThePrereleaseChannel(t *testing.T) {
+	latestRequests := 0
+	nextRequests := 0
+	path := filepath.Join(t.TempDir(), "update-check.json")
+	latest := registry(t, `{"version":"25.1.0"}`, &latestRequests)
+	next := registry(t, `{"version":"26.0.0-rc.2"}`, &nextRequests)
+
+	stable := &Checker{
+		RegistryURL: latest, PrereleaseRegistryURL: next,
+		CachePath: path, Current: "25.0.0",
+	}
+	if got := stable.Latest(time.Second); got != "25.1.0" {
+		t.Fatalf("stable lookup = %q, want 25.1.0", got)
+	}
+
+	preview := &Checker{
+		RegistryURL: latest, PrereleaseRegistryURL: next,
+		CachePath: path, Current: "26.0.0-rc.1",
+	}
+	if got := preview.Latest(time.Second); got != "26.0.0-rc.2" {
+		t.Errorf("prerelease lookup reused the stable cache: %q", got)
+	}
+	if latestRequests != 2 || nextRequests != 1 {
+		t.Errorf("requests latest=%d next=%d, want latest=2 next=1", latestRequests, nextRequests)
+	}
+}
+
 // Nothing to say when the running version is current, and nothing to say when
 // it is ahead -- a developer must not be told to "update" to something older.
 func TestNoNoticeWhenCurrentOrAhead(t *testing.T) {
@@ -48,11 +116,20 @@ func TestNoNoticeWhenCurrentOrAhead(t *testing.T) {
 // Startup is the reason this binary exists. A cached answer must not cost a
 // request, or every command pays for the check.
 func TestAFreshCacheMakesNoRequest(t *testing.T) {
+	version := "1.0.0"
 	requests := 0
-	server := registry(t, `{"version":"2.0.0"}`, &requests)
-	path := filepath.Join(t.TempDir(), "update-check.json")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.Header().Set("content-type", "application/json")
+		w.Write([]byte(`{"version":"` + version + `"}`))
+	}))
+	defer server.Close()
 
-	checker := &Checker{RegistryURL: server, CachePath: path, Current: "1.0.0"}
+	checker := &Checker{
+		RegistryURL: server.URL,
+		CachePath:   filepath.Join(t.TempDir(), "update-check.json"),
+		Current:     "1.0.0",
+	}
 
 	// The second run is silent -- that is the notice throttle, covered
 	// separately. What matters here is that it did not go to the network.
@@ -62,8 +139,14 @@ func TestAFreshCacheMakesNoRequest(t *testing.T) {
 	if requests != 1 {
 		t.Errorf("made %d requests, want the second answered from cache", requests)
 	}
-	if got := checker.Latest(time.Second); got != "2.0.0" {
-		t.Errorf("cached version = %q, want 2.0.0", got)
+
+	// An explicit update refreshes even a fresh background cache.
+	version = "2.0.0"
+	if got := checker.ExplicitStable(); got != "2.0.0" {
+		t.Errorf("ExplicitStable() = %q, want newly published 2.0.0", got)
+	}
+	if requests != 2 {
+		t.Errorf("made %d requests, want explicit lookup to refresh the cache", requests)
 	}
 }
 
@@ -142,6 +225,7 @@ func TestCompareOrdersVersions(t *testing.T) {
 		{"0.6.0-preview", "0.6.0", -1},
 		{"0.6.0", "0.6.0-preview", 1},
 		{"0.6.0-preview", "0.6.1-preview", -1},
+		{"26.0.0-rc.1", "26.0.0-rc.2", -1},
 		{"(devel)", "9.9.9", 1},
 	} {
 		if got := Compare(probe.a, probe.b); got != probe.want {
@@ -151,12 +235,25 @@ func TestCompareOrdersVersions(t *testing.T) {
 }
 
 // registry serves one npm-shaped response and optionally counts requests.
+func registryPayload(version string) string {
+	if version == "" {
+		return ""
+	}
+
+	return `{"version":"` + version + `"}`
+}
+
 func registry(t *testing.T, body string, requests *int) string {
 	t.Helper()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if requests != nil {
 			*requests++
+		}
+		if body == "" {
+			w.WriteHeader(http.StatusInternalServerError)
+
+			return
 		}
 		w.Header().Set("content-type", "application/json")
 		w.Write([]byte(body))


### PR DESCRIPTION
Two fixes the `26.0.0-rc.1` release needs, generated from
appwrite/sdk-generator 2.10.5.

## ldid

The release run failed twice on the same step, both times before goreleaser, so
nothing was ever uploaded or published and the version stayed reusable.

First: `sudo apt-get install -y ldid` -- no apt package named ldid exists on any
Ubuntu release. `scripts/adhoc-sign.sh` exits 1 without codesign or ldid, so
goreleaser's build hook failed and the release produced no binaries.

Second: the replacement step downloaded and checksummed ldid successfully, then
failed on `ldid -V`. ldid has no version flag -- `-V`, `-v` and `--version` all
print usage and exit 1 -- so the smoke check failed the step it was meant to be
reassuring about. It is now `command -v ldid`, the gate `adhoc-sign.sh` itself
uses.

The binary is the upstream prebuilt from ProcursusTeam/ldid, pinned by version
and SHA-256, because it signs every macOS artifact the release ships.

## Prerelease updates

`update` resolved the npm `latest` dist-tag, which serves the last stable release
while a release candidate sits on `next`. A tester on rc.1 who ran it left the rc
line entirely rather than moving to rc.2 (appwrite/sdk-generator#1749).

It now queries the prerelease channel when the running build is a prerelease, and
refuses to install an older version without `--force`.

## Verification

The ldid step, run in `ubuntu:24.04` end to end, checking exit status rather than
output:

```
/tmp/ldid: OK
/usr/local/bin/ldid
STEP EXIT CODE = 0
```

Signing checked against the property `install.sh` tests -- the exit code of
`codesign -dv`: a darwin/amd64 build as the Go linker leaves it exits **1**
("code object is not signed at all"); after `ldid -S` it exits **0**.

The update guard checked on a binary stamped `26.0.0-rc.1`:

```
$ ./appwrite update
✗ Error: refusing to downgrade appwrite from 26.0.0-rc.1 to 25.1.0. Re-run with --force to continue
$ ./appwrite --version
appwrite version 26.0.0-rc.1
```

The binary was not replaced. `go build ./...`, `gofmt -l`, `go vet` and
`go test ./...` are clean over the regenerated tree.

## Scope

The regenerated tree differs from `master` in exactly these seven files.

One thing left as-is: `update --manual` still prints an Option 3 `curl` line for
whatever version it resolved, without running the downgrade guard, so on an rc it
can advertise an older build. Cosmetic next to the update path itself, and worth
a follow-up rather than another release cycle.
